### PR TITLE
Handle missing console.debug() function in Internet Explorer 10

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -24,7 +24,7 @@
         if (typeof console === "undefined") {
             return noop;
         } else if (typeof console[methodName] === "undefined") {
-            return console.log || noop;
+            return boundToConsole(console, 'log') || noop;
         } else {
             return boundToConsole(console, methodName);
         }


### PR DESCRIPTION
IE 10 console object is defined, however, there is no function console.debug(). In this case the logging function will be bound to the default console.log(). This must be done using the boundToConsole() function or IE will produces a " Invalid calling object" error.
