### PR TITLE
Added fix for Private mode in Safari

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -80,9 +80,6 @@
 
         function localStorageAvailable() {
             try {
-                window.localStorage.test = 'test';
-                window.localStorage.removeItem('test');
-
                 return (typeof window !== undefinedType &&
                         window.localStorage !== undefined);
             } catch (e) {
@@ -91,7 +88,8 @@
         }
 
         function persistLevelIfPossible(levelNum) {
-            var levelName;
+            var localStorageFail = false,
+                levelName;
 
             for (var key in self.levels) {
                 if (self.levels.hasOwnProperty(key) && self.levels[key] === levelNum) {
@@ -101,11 +99,22 @@
             }
 
             if (localStorageAvailable()) {
-                window.localStorage['loglevel'] = levelName;
-            } else if (cookiesAvailable()) {
-                window.document.cookie = "loglevel=" + levelName + ";";
+                /*
+                 * Setting localStorage can create a DOM 22 Exception if running in Private mode
+                 * in Safari, so even if it is available we need to catch any errors when trying
+                 * to write to it
+                 */
+                try {
+                    window.localStorage['loglevel'] = levelName;
+                } catch (e) {
+                    localStorageFail = true;
+                }
             } else {
-                return;
+                localStorageFail = true;
+            }
+
+            if (localStorageFail && cookiesAvailable()) {
+                window.document.cookie = "loglevel=" + levelName + ";";
             }
         }
 


### PR DESCRIPTION
Running loglevel in Safari with Private mode (which I often do for testing) creates a DOM 22 Exception. I assume this is because you can't use local storage in Private Mode.

The added code will cause the exception in the `localStorageAvailable` check. It's not terribly elegant and seems strange _before_ running the checks for the `localStorage` object, but it does work.
