### PR TITLE
window.localstorage null fix

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -81,7 +81,8 @@
         function localStorageAvailable() {
             try {
                 return (typeof window !== undefinedType &&
-                        window.localStorage !== undefined);
+                        window.localStorage !== undefined &&
+                        window.localStorage !== null);
             } catch (e) {
                 return false;
             }


### PR DESCRIPTION
When localstorage is disabled inside a browser, it is null which wasn't accounted for.
