### PR TITLE
added ability to replace console

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -203,6 +203,16 @@
             return self;
         };
 
+		// Replace console.log with loglevel https://github.com/pimterry/loglevel/issues/42
+		var _console = window.console;
+		self.replaceConsole = function() {
+			window.console = self;
+		}
+
+		self.restoreConsole = function() {
+			window.console = _console;
+		}
+
         loadPersistedLevel();
         return self;
     }));

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -207,11 +207,11 @@
 		var _console = window.console;
 		self.replaceConsole = function() {
 			window.console = self;
-		}
+		};
 
 		self.restoreConsole = function() {
 			window.console = _console;
-		}
+		};
 
         loadPersistedLevel();
         return self;


### PR DESCRIPTION
This push implements two functions allowing loglevel to replace window.console but also restore it if required. I have done a manual test and both functions worked correctly.

This is to add the feature requested here: #42