### PR TITLE
Adjustment for scoping

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,13 @@ module.exports = function (grunt) {
                     vendor: 'test/vendor/*.js'
                 }
             },
+            context: {
+                src: 'test/test-context-using-apply.test.js',
+                options: {
+                    specs: 'test/global-integration-with-new-context.js',
+                    vendor: 'test/vendor/*.js'
+                }
+            },
             withCoverage: {
                 src: 'lib/**/*.js',
                 options: {
@@ -174,6 +181,15 @@ module.exports = function (grunt) {
         },
         qunit: {
             all: ['test/*-qunit.html']
+        },
+        preprocess: {
+            "test-context-using-apply": {
+                src: 'test/test-context-using-apply.js',
+                dest: 'test/test-context-using-apply.test.js'
+            }
+        },
+        clean:{
+            test:['test/test-context-using-apply.test.js']
         }
     });
 
@@ -190,12 +206,14 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-connect');
     grunt.loadNpmTasks('grunt-open');
     grunt.loadNpmTasks('grunt-saucelabs');
+    grunt.loadNpmTasks('grunt-preprocess');
+    grunt.loadNpmTasks('grunt-contrib-clean');
 
     // Build a distributable release
     grunt.registerTask('dist', ['test', 'concat', 'uglify']);
 
     // Check everything is good
-    grunt.registerTask('test', ['jshint', 'jasmine:requirejs', 'jasmine:global', 'jasmine_node', 'jasmine:withCoverage', 'qunit']);
+    grunt.registerTask('test', ['jshint', 'jasmine:requirejs', 'jasmine:global', 'preprocess', 'jasmine:context', 'clean:test', 'jasmine_node', 'jasmine:withCoverage', 'qunit']);
 
     // Test with a live server and an actual browser
     grunt.registerTask('integration-test', ['jasmine:requirejs:src:build', 'open:jasmine', 'connect:test:keepalive']);

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -1,209 +1,205 @@
 /*
- * loglevel - https://github.com/pimterry/loglevel
- *
- * Copyright (c) 2013 Tim Perry
- * Licensed under the MIT license.
- */
-
-;(function (undefined) {
+* loglevel - https://github.com/pimterry/loglevel
+*
+* Copyright (c) 2013 Tim Perry
+* Licensed under the MIT license.
+*/
+(function (root, definition) {
+    if (typeof module === 'object' && module.exports && typeof require === 'function') {
+        module.exports = definition();
+    } else if (typeof define === 'function' && typeof define.amd === 'object') {
+        define(definition);
+    } else {
+        root.log = definition();
+    }
+}(this, function () {
+    var self = {};
+    var noop = function() {};
     var undefinedType = "undefined";
 
-    (function (name, definition) {
-        if (typeof module === 'object' && module.exports && typeof require === 'function') {
-            module.exports = definition();
-        } else if (typeof define === 'function' && typeof define.amd === 'object') {
-            define(definition);
-        } else {
-            this[name] = definition();
-        }
-    }('log', function () {
-        var self = {};
-        var noop = function() {};
-
-        function realMethod(methodName) {
-            if (typeof console === undefinedType) {
+    function realMethod(methodName) {
+        if (typeof console === undefinedType) {
+            return noop;
+        } else if (console[methodName] === undefined) {
+            if (console.log !== undefined) {
+                return boundToConsole(console, 'log');
+            } else {
                 return noop;
-            } else if (console[methodName] === undefined) {
-                if (console.log !== undefined) {
-                    return boundToConsole(console, 'log');
-                } else {
-                    return noop;
-                }
+            }
+        } else {
+            return boundToConsole(console, methodName);
+        }
+    }
+
+    function boundToConsole(console, methodName) {
+        var method = console[methodName];
+        if (method.bind === undefined) {
+            if (Function.prototype.bind === undefined) {
+                return functionBindingWrapper(method, console);
             } else {
-                return boundToConsole(console, methodName);
-            }
-        }
-
-        function boundToConsole(console, methodName) {
-            var method = console[methodName];
-            if (method.bind === undefined) {
-                if (Function.prototype.bind === undefined) {
-                    return functionBindingWrapper(method, console);
-                } else {
-                    try {
-                        return Function.prototype.bind.call(console[methodName], console);
-                    } catch (e) {
-                        // In IE8 + Modernizr, the bind shim will reject the above, so we fall back to wrapping
-                        return functionBindingWrapper(method, console);
-                    }
-                }
-            } else {
-                return console[methodName].bind(console);
-            }
-        }
-
-        function functionBindingWrapper(f, context) {
-            return function() {
-                Function.prototype.apply.apply(f, [context, arguments]);
-            };
-        }
-
-        var logMethods = [
-            "trace",
-            "debug",
-            "info",
-            "warn",
-            "error"
-        ];
-
-        function replaceLoggingMethods(methodFactory) {
-            for (var ii = 0; ii < logMethods.length; ii++) {
-                self[logMethods[ii]] = methodFactory(logMethods[ii]);
-            }
-        }
-
-        function cookiesAvailable() {
-            return (typeof window !== undefinedType &&
-                    window.document !== undefined &&
-                    window.document.cookie !== undefined);
-        }
-
-        function localStorageAvailable() {
-            try {
-                return (typeof window !== undefinedType &&
-                        window.localStorage !== undefined &&
-                        window.localStorage !== null);
-            } catch (e) {
-                return false;
-            }
-        }
-
-        function persistLevelIfPossible(levelNum) {
-            var localStorageFail = false,
-                levelName;
-
-            for (var key in self.levels) {
-                if (self.levels.hasOwnProperty(key) && self.levels[key] === levelNum) {
-                    levelName = key;
-                    break;
-                }
-            }
-
-            if (localStorageAvailable()) {
-                /*
-                 * Setting localStorage can create a DOM 22 Exception if running in Private mode
-                 * in Safari, so even if it is available we need to catch any errors when trying
-                 * to write to it
-                 */
                 try {
-                    window.localStorage['loglevel'] = levelName;
+                    return Function.prototype.bind.call(console[methodName], console);
                 } catch (e) {
-                    localStorageFail = true;
+                    // In IE8 + Modernizr, the bind shim will reject the above, so we fall back to wrapping
+                    return functionBindingWrapper(method, console);
                 }
-            } else {
+            }
+        } else {
+            return console[methodName].bind(console);
+        }
+    }
+
+    function functionBindingWrapper(f, context) {
+        return function() {
+            Function.prototype.apply.apply(f, [context, arguments]);
+        };
+    }
+
+    var logMethods = [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error"
+    ];
+
+    function replaceLoggingMethods(methodFactory) {
+        for (var ii = 0; ii < logMethods.length; ii++) {
+            self[logMethods[ii]] = methodFactory(logMethods[ii]);
+        }
+    }
+
+    function cookiesAvailable() {
+        return (typeof window !== undefinedType &&
+                window.document !== undefined &&
+                window.document.cookie !== undefined);
+    }
+
+    function localStorageAvailable() {
+        try {
+            return (typeof window !== undefinedType &&
+                    window.localStorage !== undefined &&
+                    window.localStorage !== null);
+        } catch (e) {
+            return false;
+        }
+    }
+
+    function persistLevelIfPossible(levelNum) {
+        var localStorageFail = false,
+            levelName;
+
+        for (var key in self.levels) {
+            if (self.levels.hasOwnProperty(key) && self.levels[key] === levelNum) {
+                levelName = key;
+                break;
+            }
+        }
+
+        if (localStorageAvailable()) {
+            /*
+             * Setting localStorage can create a DOM 22 Exception if running in Private mode
+             * in Safari, so even if it is available we need to catch any errors when trying
+             * to write to it
+             */
+            try {
+                window.localStorage['loglevel'] = levelName;
+            } catch (e) {
                 localStorageFail = true;
             }
-
-            if (localStorageFail && cookiesAvailable()) {
-                window.document.cookie = "loglevel=" + levelName + ";";
-            }
+        } else {
+            localStorageFail = true;
         }
 
-        var cookieRegex = /loglevel=([^;]+)/;
+        if (localStorageFail && cookiesAvailable()) {
+            window.document.cookie = "loglevel=" + levelName + ";";
+        }
+    }
 
-        function loadPersistedLevel() {
-            var storedLevel;
+    var cookieRegex = /loglevel=([^;]+)/;
 
-            if (localStorageAvailable()) {
-                storedLevel = window.localStorage['loglevel'];
-            }
+    function loadPersistedLevel() {
+        var storedLevel;
 
-            if (storedLevel === undefined && cookiesAvailable()) {
-                var cookieMatch = cookieRegex.exec(window.document.cookie) || [];
-                storedLevel = cookieMatch[1];
-            }
-            
-            if (self.levels[storedLevel] === undefined) {
-                storedLevel = "WARN";
-            }
-
-            self.setLevel(self.levels[storedLevel]);
+        if (localStorageAvailable()) {
+            storedLevel = window.localStorage['loglevel'];
         }
 
-        /*
-         *
-         * Public API
-         *
-         */
+        if (storedLevel === undefined && cookiesAvailable()) {
+            var cookieMatch = cookieRegex.exec(window.document.cookie) || [];
+            storedLevel = cookieMatch[1];
+        }
+        
+        if (self.levels[storedLevel] === undefined) {
+            storedLevel = "WARN";
+        }
 
-        self.levels = { "TRACE": 0, "DEBUG": 1, "INFO": 2, "WARN": 3,
-            "ERROR": 4, "SILENT": 5};
+        self.setLevel(self.levels[storedLevel]);
+    }
 
-        self.setLevel = function (level) {
-            if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
-                persistLevelIfPossible(level);
+    /*
+     *
+     * Public API
+     *
+     */
 
-                if (level === self.levels.SILENT) {
-                    replaceLoggingMethods(function () {
-                        return noop;
-                    });
-                    return;
-                } else if (typeof console === undefinedType) {
-                    replaceLoggingMethods(function (methodName) {
-                        return function () {
-                            if (typeof console !== undefinedType) {
-                                self.setLevel(level);
-                                self[methodName].apply(self, arguments);
-                            }
-                        };
-                    });
-                    return "No console available for logging";
-                } else {
-                    replaceLoggingMethods(function (methodName) {
-                        if (level <= self.levels[methodName.toUpperCase()]) {
-                            return realMethod(methodName);
-                        } else {
-                            return noop;
+    self.levels = { "TRACE": 0, "DEBUG": 1, "INFO": 2, "WARN": 3,
+        "ERROR": 4, "SILENT": 5};
+
+    self.setLevel = function (level) {
+        if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
+            persistLevelIfPossible(level);
+
+            if (level === self.levels.SILENT) {
+                replaceLoggingMethods(function () {
+                    return noop;
+                });
+                return;
+            } else if (typeof console === undefinedType) {
+                replaceLoggingMethods(function (methodName) {
+                    return function () {
+                        if (typeof console !== undefinedType) {
+                            self.setLevel(level);
+                            self[methodName].apply(self, arguments);
                         }
-                    });
-                }
-            } else if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
-                self.setLevel(self.levels[level.toUpperCase()]);
+                    };
+                });
+                return "No console available for logging";
             } else {
-                throw "log.setLevel() called with invalid level: " + level;
+                replaceLoggingMethods(function (methodName) {
+                    if (level <= self.levels[methodName.toUpperCase()]) {
+                        return realMethod(methodName);
+                    } else {
+                        return noop;
+                    }
+                });
             }
-        };
+        } else if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
+            self.setLevel(self.levels[level.toUpperCase()]);
+        } else {
+            throw "log.setLevel() called with invalid level: " + level;
+        }
+    };
 
-        self.enableAll = function() {
-            self.setLevel(self.levels.TRACE);
-        };
+    self.enableAll = function() {
+        self.setLevel(self.levels.TRACE);
+    };
 
-        self.disableAll = function() {
-            self.setLevel(self.levels.SILENT);
-        };
+    self.disableAll = function() {
+        self.setLevel(self.levels.SILENT);
+    };
 
-        // Grab the current global log variable in case of overwrite
-        var _log = (typeof window !== undefinedType) ? window.log : undefined;
-        self.noConflict = function() {
-            if (typeof window !== undefinedType &&
-                   window.log === self) {
-                window.log = _log;
-            }
+    // Grab the current global log variable in case of overwrite
+    var _log = (typeof window !== undefinedType) ? window.log : undefined;
+    self.noConflict = function() {
+        if (typeof window !== undefinedType &&
+               window.log === self) {
+            window.log = _log;
+        }
 
-            return self;
-        };
-
-        loadPersistedLevel();
         return self;
-    }));
-})();
+    };
+
+    loadPersistedLevel();
+    return self;
+}));

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "grunt-jasmine-node": "~0.2.1",
     "grunt-coveralls": "^1.0.0",
     "grunt-contrib-qunit": "~0.5.2",
+    "grunt-preprocess": "^4.0.0",
+    "grunt-contrib-clean": "^0.6.0",
     "qunitjs": "1.14.0"
   },
   "jam": {

--- a/test/global-integration-with-new-context.js
+++ b/test/global-integration-with-new-context.js
@@ -1,0 +1,29 @@
+/* global MyCustomLogger, log */
+"use strict";
+
+describe("loglevel from a global <script> tag with a custom context", function () {
+    it("is available globally", function () {
+        expect(MyCustomLogger).not.toBeUndefined();
+    });
+
+    it("doesn't have log defined globally", function () {
+        expect(window.log).not.toBeDefined();
+    });
+
+    it("allows setting the logging level", function () {
+        MyCustomLogger.setLevel(MyCustomLogger.levels.TRACE);
+        MyCustomLogger.setLevel(MyCustomLogger.levels.DEBUG);
+        MyCustomLogger.setLevel(MyCustomLogger.levels.INFO);
+        MyCustomLogger.setLevel(MyCustomLogger.levels.WARN);
+        MyCustomLogger.setLevel(MyCustomLogger.levels.ERROR);
+    });
+
+    it("successfully logs", function () {
+        window.console = { "log": jasmine.createSpy("log") };
+
+        MyCustomLogger.setLevel(MyCustomLogger.levels.INFO);
+        MyCustomLogger.info("test message");
+
+        expect(console.log).toHaveBeenCalledWith("test message");
+    });
+});

--- a/test/test-context-using-apply.js
+++ b/test/test-context-using-apply.js
@@ -1,0 +1,6 @@
+"use strict";
+/* jshint node:true */
+var MyCustomLogger = (function() {
+    // @include ../lib/loglevel.js
+    return this.log;
+}).apply({});


### PR DESCRIPTION
The code was wrapped in two anonymous functions, which could cause `this` to be undefined depending on how the loglevel code was included in a project. 

Only using one anonymous function and having this be at the "top-level" allows the code to be wrapped and invoked with apply like so:

``` javascript
var myScope = {}:
(function(){
 // loglevel.js source
 // "this" will equal myScope, since the "this" in loglevel.js is in this scope.
}).apply(myScope);
myScope.log.debug("log was defined on myScope");
```

The code change follows the same pattern as this:
https://github.com/marionettejs/backbone.marionette/blob/master/src/build/marionette.core.js

I'd love to write a unit test but I'd have to adjust the `Gruntfile.js` and include grunt-preprocess or grunt-rigger, which are code injection/include tools, to generate a test that includes the `loglevel.js` wrapped in a function invoked with apply. If you want me to do this I will. 

I also hope that my change doesn't affect anything that the `undefined` argument was doing.
https://github.com/pimterry/loglevel/blob/master/lib/loglevel.js#L8

Thanks,
Gianni
