### PR TITLE
Refactor setLogLevel()

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -20,15 +20,18 @@
 
     function realMethod(methodName) {
         if (typeof console === undefinedType) {
-            return noop;
-        } else if (console[methodName] === undefined) {
-            if (console.log !== undefined) {
-                return boundToConsole(console, 'log');
-            } else {
-                return noop;
-            }
-        } else {
+            return function () {
+                if (typeof console !== undefinedType) {
+                    replaceLoggingMethods();
+                    self[methodName].apply(self, arguments);
+                }
+            };
+        } else if (typeof console[methodName] === "function") {
             return boundToConsole(console, methodName);
+        } else if (typeof console.log === "function") {
+            return boundToConsole(console, 'log');
+        } else {
+            return noop;
         }
     }
 
@@ -64,9 +67,14 @@
         "error"
     ];
 
-    function replaceLoggingMethods(methodFactory) {
-        for (var ii = 0; ii < logMethods.length; ii++) {
-            self[logMethods[ii]] = methodFactory(logMethods[ii]);
+    function replaceLoggingMethods() {
+        for (var i = 0; i < logMethods.length; i++) {
+            var methodName = logMethods[i];
+            if (currentLevel <= self.levels[methodName.toUpperCase()]) {
+                self[methodName] = realMethod(methodName);
+            } else {
+                self[methodName] = noop;
+            }
         }
     }
 
@@ -154,30 +162,9 @@
         if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
             currentLevel = level;
             persistLevelIfPossible(level);
-
-            if (level === self.levels.SILENT) {
-                replaceLoggingMethods(function () {
-                    return noop;
-                });
-                return;
-            } else if (typeof console === undefinedType) {
-                replaceLoggingMethods(function (methodName) {
-                    return function () {
-                        if (typeof console !== undefinedType) {
-                            self.setLevel(level);
-                            self[methodName].apply(self, arguments);
-                        }
-                    };
-                });
+            replaceLoggingMethods();
+            if (typeof console === undefinedType && level < self.levels.SILENT) {
                 return "No console available for logging";
-            } else {
-                replaceLoggingMethods(function (methodName) {
-                    if (level <= self.levels[methodName.toUpperCase()]) {
-                        return realMethod(methodName);
-                    } else {
-                        return noop;
-                    }
-                });
             }
         } else {
             throw "log.setLevel() called with invalid level: " + level;


### PR DESCRIPTION
By moving the no-console-available helper function into `realMethod()`, most of the code in `setLogLevel()` becomes obsolete and `replaceLoggingMethods()` no longer requires any arguments. 
