### PR TITLE
Refactored log level storage to window.localStorage (or cookies)

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -81,25 +81,8 @@
         }
     }
 
-    function cookiesAvailable() {
-        return (typeof window !== undefinedType &&
-                window.document !== undefined &&
-                window.document.cookie !== undefined);
-    }
-
-    function localStorageAvailable() {
-        try {
-            return (typeof window !== undefinedType &&
-                    window.localStorage !== undefined &&
-                    window.localStorage !== null);
-        } catch (e) {
-            return false;
-        }
-    }
-
     function persistLevelIfPossible(levelNum) {
-        var localStorageFail = false,
-            levelName;
+        var levelName;
 
         for (var key in self.levels) {
             if (self.levels.hasOwnProperty(key) && self.levels[key] === levelNum) {
@@ -108,38 +91,29 @@
             }
         }
 
-        if (localStorageAvailable()) {
-            /*
-             * Setting localStorage can create a DOM 22 Exception if running in Private mode
-             * in Safari, so even if it is available we need to catch any errors when trying
-             * to write to it
-             */
-            try {
-                window.localStorage['loglevel'] = levelName;
-            } catch (e) {
-                localStorageFail = true;
-            }
-        } else {
-            localStorageFail = true;
-        }
+        // Use localStorage if available
+        try {
+            window.localStorage['loglevel'] = levelName;
+            return;
+        } catch (ignore) {}
 
-        if (localStorageFail && cookiesAvailable()) {
+        // Use session cookie as fallback
+        try {
             window.document.cookie = "loglevel=" + levelName + ";";
-        }
+        } catch (ignore) {}
     }
-
-    var cookieRegex = /loglevel=([^;]+)/;
 
     function loadPersistedLevel() {
         var storedLevel;
 
-        if (localStorageAvailable()) {
+        try {
             storedLevel = window.localStorage['loglevel'];
-        }
+        } catch (ignore) {}
 
-        if (storedLevel === undefined && cookiesAvailable()) {
-            var cookieMatch = cookieRegex.exec(window.document.cookie) || [];
-            storedLevel = cookieMatch[1];
+        if (typeof storedLevel === undefinedType) {
+            try {
+                storedLevel = /loglevel=([^;]+)/.exec(window.document.cookie)[1];
+            } catch (ignore) {}
         }
         
         if (self.levels[storedLevel] === undefined) {


### PR DESCRIPTION
By relying on try-catch-blocks (which are needed anyway for safety), we can omit most of the code checking for availability of `window.localStorage` and similar.
