### PR TITLE
Refactored to use more generic bindMethod() function.

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -21,36 +21,28 @@
         if (typeof console === undefinedType) {
             return false; // We can't build a real method without a console to log to
         } else if (typeof console[methodName] === "function") {
-            return boundToConsole(console, methodName);
+            return bindMethod(console, methodName);
         } else if (typeof console.log === "function") {
-            return boundToConsole(console, 'log');
+            return bindMethod(console, 'log');
         } else {
             return noop;
         }
     }
 
-    function boundToConsole(console, methodName) {
-        var method = console[methodName];
-        if (method.bind === undefined) {
-            if (Function.prototype.bind === undefined) {
-                return functionBindingWrapper(method, console);
-            } else {
-                try {
-                    return Function.prototype.bind.call(console[methodName], console);
-                } catch (e) {
-                    // In IE8 + Modernizr, the bind shim will reject the above, so we fall back to wrapping
-                    return functionBindingWrapper(method, console);
-                }
-            }
+    function bindMethod(obj, methodName) {
+        var method = obj[methodName];
+        if (typeof method.bind === 'function') {
+            return method.bind(obj);
         } else {
-            return console[methodName].bind(console);
+            try {
+                return Function.prototype.bind.call(method, obj);
+            } catch (e) {
+                // Missing bind shim or IE8 + Modernizr, fallback to wrapping
+                return function() {
+                    return method.apply(obj, arguments);
+                };
+            }
         }
-    }
-
-    function functionBindingWrapper(f, context) {
-        return function() {
-            Function.prototype.apply.apply(f, [context, arguments]);
-        };
     }
 
     function enableLoggingWhenConsoleArrives(methodName, level) {


### PR DESCRIPTION
Because more refactorings are... more.
