### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+
+# EditorConfig defines and maintains consistent coding styles between different
+# editors and IDEs: http://EditorConfig.org/
+# Top-most EditorConfig file
+root = true
+
+# All files
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+max_line_length = 80
+
+[*.json]
+indent_size = 2
+


### PR DESCRIPTION
EditorConfig helps developers define and maintain consistent coding styles
between different editors and IDEs. The EditorConfig project consists of a file
format for defining coding styles and a collection of text editor plugins that
enable editors to read the file format and adhere to defined styles.
EditorConfig files are easily readable and they work nicely with version control
systems.