### PR TITLE
Make log level persisting optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The loglevel API is extremely minimal. All methods are available on the root log
   * As a string, like 'error' (case-insensitive) ← _for a reasonable practical balance_
   * As a numeric index from 0 (trace) to 5 (silent) ← _deliciously terse, and more easily programmable (...although, why?)_
 
-  Where possible the log level will be persisted. LocalStorage will be used if available, falling back to cookies if not. If neither is available in the current environment (i.e. in Node) persistence will be skipped.
+  Where possible the log level will be persisted. LocalStorage will be used if available, falling back to cookies if not. If neither is available in the current environment (i.e. in Node) or if you pass `false` as the second argument, persistence will be skipped.
   
   If log.setLevel() is called when a console object is not available (in IE 8 or 9 before the developer tools have been opened, for example) logging will remain silent until the console becomes available, and then begin logging at the requested level.
   

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -118,12 +118,14 @@
                enableLoggingWhenConsoleArrives(methodName, level);
     };
 
-    self.setLevel = function (level) {
+    self.setLevel = function (level, persist) {
         if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
             level = self.levels[level.toUpperCase()];
         }
         if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
-            persistLevelIfPossible(level);
+            if (persist !== false) {  // defaults to true
+                persistLevelIfPossible(level);
+            }
             replaceLoggingMethods(level);
             if (typeof console === undefinedType && level < self.levels.SILENT) {
                 return "No console available for logging";
@@ -133,12 +135,12 @@
         }
     };
 
-    self.enableAll = function() {
-        self.setLevel(self.levels.TRACE);
+    self.enableAll = function(persist) {
+        self.setLevel(self.levels.TRACE, persist);
     };
 
-    self.disableAll = function() {
-        self.setLevel(self.levels.SILENT);
+    self.disableAll = function(persist) {
+        self.setLevel(self.levels.SILENT, persist);
     };
 
     // Grab the current global log variable in case of overwrite

--- a/test/level-setting-test.js
+++ b/test/level-setting-test.js
@@ -26,7 +26,7 @@ define(['../lib/loglevel'], function(log) {
 
         describe("log.enableAll()", function() {
             it("enables all log methods", function() {
-                log.enableAll();
+                log.enableAll(false);
 
                 for (var ii = 0; ii < logMethods.length; ii++) {
                     var method = logMethods[ii];
@@ -39,7 +39,7 @@ define(['../lib/loglevel'], function(log) {
 
         describe("log.disableAll()", function() {
             it("disables all log methods", function() {
-                log.disableAll();
+                log.disableAll(false);
 
                 for (var ii = 0; ii < logMethods.length; ii++) {
                     var method = logMethods[ii];
@@ -85,8 +85,7 @@ define(['../lib/loglevel'], function(log) {
         describe("setting log level by name", function() {
             function itCanSetLogLevelTo(level) {
                 it("can set log level to " + level, function() {
-                    log.disableAll();
-                    log.setLevel(level);
+                    log.setLevel(level, false);
 
                     log[level]("log message");
                     expect(console[level]).toHaveBeenCalled();

--- a/test/local-storage-test.js
+++ b/test/local-storage-test.js
@@ -5,7 +5,6 @@ define(['test/test-helpers'], function(testHelpers) {
     var it = testHelpers.itWithFreshLog;
 
     var originalConsole = window.console;
-    var originalDocument = window.document;
 
     describeIf(testHelpers.isLocalStorageAvailable(), "Local storage persistence tests:", function() {
 
@@ -42,6 +41,11 @@ define(['test/test-helpers'], function(testHelpers) {
             it("log.setLevel() sets a cookie with the given level", function(log) {
                 log.setLevel("debug");
                 expect("debug").toBeTheStoredLevel();
+            });
+
+            it("log.setLevel() does not set a cookie if `persist` argument is false", function(log) {
+                log.setLevel("debug", false);
+                expect("debug").not.toBeTheStoredLevel();
             });
         });
         
@@ -84,6 +88,13 @@ define(['test/test-helpers'], function(testHelpers) {
 
                 expect("error").toBeTheStoredLevel();
                 expect("info").not.toBeTheStoredLevel();
+            });
+
+            it("log.setLevel() does not overwrite the saved level if `persist` argument is false", function(log) {
+                log.setLevel("error", false);
+
+                expect("info").toBeTheStoredLevel();
+                expect("error").not.toBeTheStoredLevel();
             });
         });
 


### PR DESCRIPTION
We want to set a higher log level in production by default but don't want it to be saved on users' browsers. Making persistence optional seemed like a good way to achieve this. The patch keeps the old behavior (persist by default) for backwards compatibility.