### PR TITLE
Don't persist the default level

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -101,7 +101,7 @@
             storedLevel = "WARN";
         }
 
-        self.setLevel(self.levels[storedLevel]);
+        self.setLevel(self.levels[storedLevel], false);
     }
 
     /*

--- a/test/local-storage-test.js
+++ b/test/local-storage-test.js
@@ -29,8 +29,8 @@ define(['test/test-helpers'], function(testHelpers) {
                 expect(log).toBeAtLevel("warn");
             });
 
-            it("warn is persisted as the current level", function(log) {
-                expect("warn").toBeTheStoredLevel();
+            it("warn is not persisted as the current level", function(log) {
+                expect("warn").not.toBeTheStoredLevel();
             });
 
             it("log can be set to info level", function(log) {
@@ -152,8 +152,8 @@ define(['test/test-helpers'], function(testHelpers) {
                 expect(log).toBeAtLevel("warn");
             });
 
-            it("warn is persisted as the current level, overriding the invalid stored level", function(log) {
-                expect("warn").toBeTheStoredLevel();
+            it("warn is not persisted as the current level", function(log) {
+                expect("warn").not.toBeTheStoredLevel();
             });
 
             it("log can be changed to info level", function(log) {


### PR DESCRIPTION
Persisting the default level in production, especially when there was no
previous value persisted causes it being set on all clients for no
reason. It is also impossible to set a new default without somehow
cleaning up the old value.