### PR TITLE
Add a `setDefaultLevel()` method that sets levels only if none were previously persisted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ The loglevel API is extremely minimal. All methods are available on the root log
   Where possible the log level will be persisted. LocalStorage will be used if available, falling back to cookies if not. If neither is available in the current environment (i.e. in Node), or if you pass `false` as the optional 'persist' second argument, persistence will be skipped.
   
   If log.setLevel() is called when a console object is not available (in IE 8 or 9 before the developer tools have been opened, for example) logging will remain silent until the console becomes available, and then begin logging at the requested level.
+
+* A `log.setDefaultLevel(level, [persist])` method.
+
+  This sets the current log level only if one has not been persisted and can’t be loaded. This is useful when initializing scripts; if a developer or user has previously called `setLevel()`, this won’t alter their settings. For example, your application might set the log level to `error` in a production environment, but when debugging an issue, you might call `setLevel("trace")` on the console to see all the logs. If that `error` setting was set using `setDefaultLevel()`, it will still say as `trace` on subsequent page loads and refreshes instead of resetting to `error`.
+
+  The `level` argument takes is the same values that you might pass to `setLevel()`. However, `persist` defaults to `false` here, unlike in `setLevel()`, where it defaults to `true`.
   
 * `log.enableAll()` and `log.disableAll()` methods.
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ The loglevel API is extremely minimal. All methods are available on the root log
   
   If log.setLevel() is called when a console object is not available (in IE 8 or 9 before the developer tools have been opened, for example) logging will remain silent until the console becomes available, and then begin logging at the requested level.
 
-* A `log.setDefaultLevel(level, [persist])` method.
+* A `log.setDefaultLevel(level)` method.
 
   This sets the current log level only if one has not been persisted and can’t be loaded. This is useful when initializing scripts; if a developer or user has previously called `setLevel()`, this won’t alter their settings. For example, your application might set the log level to `error` in a production environment, but when debugging an issue, you might call `setLevel("trace")` on the console to see all the logs. If that `error` setting was set using `setDefaultLevel()`, it will still say as `trace` on subsequent page loads and refreshes instead of resetting to `error`.
 
-  The `level` argument takes is the same values that you might pass to `setLevel()`. However, `persist` defaults to `false` here, unlike in `setLevel()`, where it defaults to `true`.
+  The `level` argument takes is the same values that you might pass to `setLevel()`. Levels set using `setDefaultLevel()` never persist to subsequent page loads.
   
 * `log.enableAll()` and `log.disableAll()` methods.
 

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -84,7 +84,7 @@
         } catch (ignore) {}
     }
 
-    function loadPersistedLevel() {
+    function getPersistedLevel() {
         var storedLevel;
 
         try {
@@ -136,12 +136,9 @@
         }
     };
 
-    // NOTE: the semantics for the `persist` argument here are different than
-    // in `setLevel()`; it defaults to `false` instead of `true` (if you are
-    // setting a *default*, you likely don't want that persisted).
-    self.setDefaultLevel = function (level, persist) {
-        if (!loadPersistedLevel()) {
-            self.setLevel(level, !!persist);
+    self.setDefaultLevel = function (level) {
+        if (!getPersistedLevel()) {
+            self.setLevel(level, false);
         }
     };
 
@@ -164,6 +161,6 @@
         return self;
     };
 
-    self.setLevel(loadPersistedLevel() || "WARN", false);
+    self.setLevel(getPersistedLevel() || "WARN", false);
     return self;
 }));

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -96,12 +96,13 @@
                 storedLevel = /loglevel=([^;]+)/.exec(window.document.cookie)[1];
             } catch (ignore) {}
         }
-        
+
+        // If the stored level is not valid, treat it as if nothing was stored.
         if (self.levels[storedLevel] === undefined) {
-            storedLevel = "WARN";
+            storedLevel = undefined;
         }
 
-        self.setLevel(self.levels[storedLevel], false);
+        return storedLevel;
     }
 
     /*
@@ -135,6 +136,15 @@
         }
     };
 
+    // NOTE: the semantics for the `persist` argument here are different than
+    // in `setLevel()`; it defaults to `false` instead of `true` (if you are
+    // setting a *default*, you likely don't want that persisted).
+    self.setDefaultLevel = function (level, persist) {
+        if (!loadPersistedLevel()) {
+            self.setLevel(level, !!persist);
+        }
+    };
+
     self.enableAll = function(persist) {
         self.setLevel(self.levels.TRACE, persist);
     };
@@ -154,6 +164,6 @@
         return self;
     };
 
-    loadPersistedLevel();
+    self.setLevel(loadPersistedLevel() || "WARN", false);
     return self;
 }));

--- a/test/default-level-test.js
+++ b/test/default-level-test.js
@@ -1,0 +1,77 @@
+"use strict";
+
+define(['test/test-helpers'], function(testHelpers) {
+    var describeIf = testHelpers.describeIf;
+    var it = testHelpers.itWithFreshLog;
+
+    var originalConsole = window.console;
+
+    describe("Setting default log level tests:", function() {
+
+        beforeEach(function() {
+            window.console = {"log" : jasmine.createSpy("console.log")};
+            this.addMatchers({
+                "toBeAtLevel" : testHelpers.toBeAtLevel,
+                "toBeTheStoredLevel" : testHelpers.toBeTheLevelStoredByLocalStorage
+            });
+
+            testHelpers.clearStoredLevels();
+        });
+
+        afterEach(function() {
+            window.console = originalConsole;
+        });
+
+        describe("If no level is saved", function() {
+            it("new level is always set", function(log) {
+                log.setDefaultLevel("trace");
+                expect(log).toBeAtLevel("trace");
+            });
+
+            it("level is not persisted if no `persist` argument is set", function(log) {
+                log.setDefaultLevel("debug");
+                expect("debug").not.toBeTheStoredLevel();
+            });
+
+            it("level is persisted if `persist` argument is true", function(log) {
+                log.setDefaultLevel("debug", true);
+                expect("debug").toBeTheStoredLevel();
+            });
+        });
+        
+        describe("If a level is saved", function () {
+            beforeEach(function () {
+                testHelpers.setStoredLevel("trace");
+            });
+            
+            it("saved level is not modified", function (log) {
+                log.setDefaultLevel("debug");
+                expect(log).toBeAtLevel("trace");
+            });
+
+            it("saved level is not modified even if `persist` argument is true", function (log) {
+                log.setDefaultLevel("debug", true);
+                expect(log).toBeAtLevel("trace");
+                expect("trace").toBeTheStoredLevel();
+            });
+        });
+
+        describe("If the level is stored incorrectly", function() {
+            beforeEach(function() {
+                testHelpers.setLocalStorageStoredLevel("gibberish");
+            });
+
+            it("new level is set", function(log) {
+                log.setDefaultLevel("debug");
+                expect(log).toBeAtLevel("debug");
+                expect("debug").not.toBeTheStoredLevel();
+            });
+
+            it("new level is saved if `persist` argument is true", function(log) {
+                log.setDefaultLevel("debug", true);
+                expect(log).toBeAtLevel("debug");
+                expect("debug").toBeTheStoredLevel();
+            });
+        });
+    });
+});

--- a/test/default-level-test.js
+++ b/test/default-level-test.js
@@ -28,14 +28,9 @@ define(['test/test-helpers'], function(testHelpers) {
                 expect(log).toBeAtLevel("trace");
             });
 
-            it("level is not persisted if no `persist` argument is set", function(log) {
+            it("level is not persisted", function(log) {
                 log.setDefaultLevel("debug");
                 expect("debug").not.toBeTheStoredLevel();
-            });
-
-            it("level is persisted if `persist` argument is true", function(log) {
-                log.setDefaultLevel("debug", true);
-                expect("debug").toBeTheStoredLevel();
             });
         });
         
@@ -48,12 +43,6 @@ define(['test/test-helpers'], function(testHelpers) {
                 log.setDefaultLevel("debug");
                 expect(log).toBeAtLevel("trace");
             });
-
-            it("saved level is not modified even if `persist` argument is true", function (log) {
-                log.setDefaultLevel("debug", true);
-                expect(log).toBeAtLevel("trace");
-                expect("trace").toBeTheStoredLevel();
-            });
         });
 
         describe("If the level is stored incorrectly", function() {
@@ -65,12 +54,6 @@ define(['test/test-helpers'], function(testHelpers) {
                 log.setDefaultLevel("debug");
                 expect(log).toBeAtLevel("debug");
                 expect("debug").not.toBeTheStoredLevel();
-            });
-
-            it("new level is saved if `persist` argument is true", function(log) {
-                log.setDefaultLevel("debug", true);
-                expect(log).toBeAtLevel("debug");
-                expect("debug").toBeTheStoredLevel();
             });
         });
     });

--- a/test/test-qunit.js
+++ b/test/test-qunit.js
@@ -30,6 +30,7 @@ test('basic test', function() {
     ok(typeof logging.warn === "function", "warn is a function");
     ok(typeof logging.error === "function", "error is a function");
     ok(typeof logging.setLevel === "function", "setLevel is a function");
+    ok(typeof logging.setDefaultLevel === "function", "setDefaultLevel is a function");
     ok(typeof logging.enableAll === "function", "enableAll is a function");
     ok(typeof logging.disableAll === "function", "disableAll is a function");
    


### PR DESCRIPTION
I had some time the other day, so I worked up this approach for solving #74. I realize it’s unsolicited, but hopefully it helps to have some working code to look at.

The idea is that, if your application automatically sets the logging level on startup, you’d use `setDefaultLevel()` instead of `setLevel()`. That way, if a developer or user opens the console and calls `setLevel()`, that setting will stick on the next page load (instead of being reset by app initialization). For example, your application might set the log level to `error` in a production environment, but when debugging an issue, you might call `setLevel("trace")` on the console to see all the logs. If that `error` setting was set using `setDefaultLevel()`, it will still say as `trace` on subsequent page loads and refreshes instead of resetting to `error`, which would have happened if page scripts used `setLevel()`.

I’m currently using a slightly more hacky version of this on a web site I’m working on (we check whether anything is stored under “loglevel” in local storage before calling `setLevel()`), but it would be nice to have it built in.