### PR TITLE
Add strict mode

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -5,6 +5,8 @@
 * Licensed under the MIT license.
 */
 (function (root, definition) {
+    "use strict";
+
     if (typeof module === 'object' && module.exports && typeof require === 'function') {
         module.exports = definition();
     } else if (typeof define === 'function' && typeof define.amd === 'object') {


### PR DESCRIPTION
Because strict mode fixes mistakes that make it difficult for JavaScript
engines to perform optimizations: strict mode code can sometimes be made
to run faster than identical code that's not strict mode.

cf.  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode