### PR TITLE
WIP: Multiple logger support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@
 root = true
 
 # All files
+[*.*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
@@ -13,6 +14,8 @@ indent_size = 4
 trim_trailing_whitespace = true
 max_line_length = 80
 
-[*.json]
+[*.md]
 indent_size = 2
 
+[*.json]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The loglevel API is extremely minimal. All methods are available on the root log
 
   In large applications, it can be incredibly useful to turn logging on and off for particular modules as you are working with them. Using the `getLogger()` method lets you create a separate logger for each part of your application with its own logging level.
 
-  Likewise, for small, independent modules, using a named logger instead of the default, root logger allows developers using your module to selectively turn on deep, trace-level logging when trying to debug problems, while logging only errors or silencing logging altogether under normal circumstances.
+  Likewise, for small, independent modules, using a named logger instead of the default root logger allows developers using your module to selectively turn on deep, trace-level logging when trying to debug problems, while logging only errors or silencing logging altogether under normal circumstances.
 
   Example usage *(using CommonJS modules, but you could do the same with any module system):*
 
@@ -180,7 +180,7 @@ The loglevel API is extremely minimal. All methods are available on the root log
   // (but nothing from module one.)
   ```
 
-  Loggers returned by `getLogger()` support all the same properties and methods and default, root logger, excepting `noConflict()` and the `getLogger()` method itself.
+  Loggers returned by `getLogger()` support all the same properties and methods as the default root logger, excepting `noConflict()` and the `getLogger()` method itself.
 
   Like the root logger, other loggers can have their logging level saved. If a logger’s level has not been saved, it will inherit the root logger’s level when it is first created. If the root logger’s level changes later, the new level will not affect other loggers that have already been created.
 
@@ -206,7 +206,7 @@ For example, a plugin to prefix all log messages with "Newsflash: " would look l
 ```javascript
 var originalFactory = log.methodFactory;
 log.methodFactory = function (methodName, logLevel, loggerName) {
-    var rawMethod = originalFactory(methodName, logLevel);
+    var rawMethod = originalFactory(methodName, logLevel, loggerName);
 
     return function (message) {
         rawMethod("Newsflash: " + message);

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -15,8 +15,6 @@
         root.log = definition();
     }
 }(this, function () {
-    var self = {};
-    var currentLevel;
     var noop = function() {};
     var undefinedType = "undefined";
 
@@ -48,13 +46,27 @@
         }
     }
 
+    // these private functions always need `this` to be set properly
+
     function enableLoggingWhenConsoleArrives(methodName, level) {
         return function () {
             if (typeof console !== undefinedType) {
-                replaceLoggingMethods(level);
-                self[methodName].apply(self, arguments);
+                replaceLoggingMethods.call(this, level);
+                this[methodName].apply(this, arguments);
             }
         };
+    }
+
+    function replaceLoggingMethods(level) {
+        for (var i = 0; i < logMethods.length; i++) {
+            var methodName = logMethods[i];
+            this[methodName] = (i < level) ? noop : this.methodFactory(methodName, level);
+        }
+    }
+
+    function defaultMethodFactory(methodName, level) {
+        return realMethod(methodName) ||
+               enableLoggingWhenConsoleArrives.call(this, methodName, level);
     }
 
     var logMethods = [
@@ -65,110 +77,139 @@
         "error"
     ];
 
-    function replaceLoggingMethods(level) {
-        for (var i = 0; i < logMethods.length; i++) {
-            var methodName = logMethods[i];
-            self[methodName] = (i < level) ? noop : self.methodFactory(methodName, level);
-        }
-    }
+    function Logger(name, level, factory) {
+      var self = this;
+      var currentLevel;
+      var storageKey = "loglevel";
+      if (name) {
+        storageKey += ":" + name;
+      }
 
-    function persistLevelIfPossible(levelNum) {
-        var levelName = (logMethods[levelNum] || 'silent').toUpperCase();
+      function persistLevelIfPossible(levelNum) {
+          var levelName = (logMethods[levelNum] || 'silent').toUpperCase();
 
-        // Use localStorage if available
-        try {
-            window.localStorage['loglevel'] = levelName;
-            return;
-        } catch (ignore) {}
+          // Use localStorage if available
+          try {
+              window.localStorage[storageKey] = levelName;
+              return;
+          } catch (ignore) {}
 
-        // Use session cookie as fallback
-        try {
-            window.document.cookie = "loglevel=" + levelName + ";";
-        } catch (ignore) {}
-    }
+          // Use session cookie as fallback
+          try {
+              window.document.cookie =
+                encodeURIComponent(storageKey) + "=" + levelName + ";";
+          } catch (ignore) {}
+      }
 
-    function getPersistedLevel() {
-        var storedLevel;
+      function getPersistedLevel() {
+          var storedLevel;
 
-        try {
-            storedLevel = window.localStorage['loglevel'];
-        } catch (ignore) {}
+          try {
+              storedLevel = window.localStorage[storageKey];
+          } catch (ignore) {}
 
-        if (typeof storedLevel === undefinedType) {
-            try {
-                storedLevel = /loglevel=([^;]+)/.exec(window.document.cookie)[1];
-            } catch (ignore) {}
-        }
+          if (typeof storedLevel === undefinedType) {
+              try {
+                  var cookie = window.document.cookie;
+                  var location = cookie.indexOf(
+                      encodeURIComponent(storageKey) + "=");
+                  if (location) {
+                      storedLevel = /^([^;]+)/.exec(cookie.slice(location))[1];
+                  }
+              } catch (ignore) {}
+          }
 
-        // If the stored level is not valid, treat it as if nothing was stored.
-        if (self.levels[storedLevel] === undefined) {
-            storedLevel = undefined;
-        }
+          // If the stored level is not valid, treat it as if nothing was stored.
+          if (self.levels[storedLevel] === undefined) {
+              storedLevel = undefined;
+          }
 
-        return storedLevel;
+          return storedLevel;
+      }
+
+      /*
+       *
+       * Public API
+       *
+       */
+
+      self.levels = { "TRACE": 0, "DEBUG": 1, "INFO": 2, "WARN": 3,
+          "ERROR": 4, "SILENT": 5};
+
+      self.methodFactory = factory || defaultMethodFactory;
+
+      self.getLevel = function () {
+          return currentLevel;
+      };
+
+      self.setLevel = function (level, persist) {
+          if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
+              level = self.levels[level.toUpperCase()];
+          }
+          if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
+              currentLevel = level;
+              if (persist !== false) {  // defaults to true
+                  persistLevelIfPossible(level);
+              }
+              replaceLoggingMethods.call(self, level);
+              if (typeof console === undefinedType && level < self.levels.SILENT) {
+                  return "No console available for logging";
+              }
+          } else {
+              throw "log.setLevel() called with invalid level: " + level;
+          }
+      };
+
+      self.setDefaultLevel = function (level) {
+          if (!getPersistedLevel()) {
+              self.setLevel(level, false);
+          }
+      };
+
+      self.enableAll = function(persist) {
+          self.setLevel(self.levels.TRACE, persist);
+      };
+
+      self.disableAll = function(persist) {
+          self.setLevel(self.levels.SILENT, persist);
+      };
+
+      // init
+      self.setLevel(getPersistedLevel() || level || "WARN", false);
     }
 
     /*
      *
-     * Public API
+     * Package-level API
      *
      */
 
-    self.levels = { "TRACE": 0, "DEBUG": 1, "INFO": 2, "WARN": 3,
-        "ERROR": 4, "SILENT": 5};
+    var defaultLogger = new Logger();
 
-    self.methodFactory = function (methodName, level) {
-        return realMethod(methodName) ||
-               enableLoggingWhenConsoleArrives(methodName, level);
-    };
-
-    self.getLevel = function () {
-        return currentLevel;
-    };
-
-    self.setLevel = function (level, persist) {
-        if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
-            level = self.levels[level.toUpperCase()];
+    var _loggersByName = {};
+    defaultLogger.getLogger = function getLogger(name) {
+        if (!name || typeof name !== "string") {
+          throw new TypeError("You must supply a name when creating a logger.");
         }
-        if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
-            currentLevel = level;
-            if (persist !== false) {  // defaults to true
-                persistLevelIfPossible(level);
-            }
-            replaceLoggingMethods(level);
-            if (typeof console === undefinedType && level < self.levels.SILENT) {
-                return "No console available for logging";
-            }
-        } else {
-            throw "log.setLevel() called with invalid level: " + level;
+
+        var logger = _loggersByName[name];
+        if (!logger) {
+          logger = _loggersByName[name] = new Logger(
+            name, defaultLogger.getLevel(), defaultLogger.methodFactory);
         }
-    };
-
-    self.setDefaultLevel = function (level) {
-        if (!getPersistedLevel()) {
-            self.setLevel(level, false);
-        }
-    };
-
-    self.enableAll = function(persist) {
-        self.setLevel(self.levels.TRACE, persist);
-    };
-
-    self.disableAll = function(persist) {
-        self.setLevel(self.levels.SILENT, persist);
+        return logger;
     };
 
     // Grab the current global log variable in case of overwrite
     var _log = (typeof window !== undefinedType) ? window.log : undefined;
-    self.noConflict = function() {
+    defaultLogger.noConflict = function() {
         if (typeof window !== undefinedType &&
-               window.log === self) {
+               window.log === defaultLogger) {
             window.log = _log;
         }
 
-        return self;
+        return defaultLogger;
     };
 
-    self.setLevel(getPersistedLevel() || "WARN", false);
-    return self;
+    return defaultLogger;
 }));

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -174,8 +174,12 @@
           self.setLevel(self.levels.SILENT, persist);
       };
 
-      // init
-      self.setLevel(getPersistedLevel() || level || "WARN", false);
+      // Initialize with the right level
+      var initialLevel = getPersistedLevel();
+      if (initialLevel == null) {
+          initialLevel = level == null ? "WARN" : level;
+      }
+      self.setLevel(initialLevel, false);
     }
 
     /*

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -48,25 +48,27 @@
 
     // these private functions always need `this` to be set properly
 
-    function enableLoggingWhenConsoleArrives(methodName, level) {
+    function enableLoggingWhenConsoleArrives(methodName, level, loggerName) {
         return function () {
             if (typeof console !== undefinedType) {
-                replaceLoggingMethods.call(this, level);
+                replaceLoggingMethods.call(this, level, loggerName);
                 this[methodName].apply(this, arguments);
             }
         };
     }
 
-    function replaceLoggingMethods(level) {
+    function replaceLoggingMethods(level, loggerName) {
         for (var i = 0; i < logMethods.length; i++) {
             var methodName = logMethods[i];
-            this[methodName] = (i < level) ? noop : this.methodFactory(methodName, level);
+            this[methodName] = (i < level) ?
+                noop :
+                this.methodFactory(methodName, level, loggerName);
         }
     }
 
-    function defaultMethodFactory(methodName, level) {
+    function defaultMethodFactory(methodName, level, loggerName) {
         return realMethod(methodName) ||
-               enableLoggingWhenConsoleArrives.call(this, methodName, level);
+               enableLoggingWhenConsoleArrives.apply(this, arguments);
     }
 
     var logMethods = [
@@ -151,7 +153,7 @@
               if (persist !== false) {  // defaults to true
                   persistLevelIfPossible(level);
               }
-              replaceLoggingMethods.call(self, level);
+              replaceLoggingMethods.call(self, level, name);
               if (typeof console === undefinedType && level < self.levels.SILENT) {
                   return "No console available for logging";
               }

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -77,7 +77,7 @@
         "error"
     ];
 
-    function Logger(name, level, factory) {
+    function Logger(name, defaultLevel, factory) {
       var self = this;
       var currentLevel;
       var storageKey = "loglevel";
@@ -177,7 +177,7 @@
       // Initialize with the right level
       var initialLevel = getPersistedLevel();
       if (initialLevel == null) {
-          initialLevel = level == null ? "WARN" : level;
+          initialLevel = defaultLevel == null ? "WARN" : defaultLevel;
       }
       self.setLevel(initialLevel, false);
     }
@@ -192,7 +192,7 @@
 
     var _loggersByName = {};
     defaultLogger.getLogger = function getLogger(name) {
-        if (!name || typeof name !== "string") {
+        if (typeof name !== "string" || name === "") {
           throw new TypeError("You must supply a name when creating a logger.");
         }
 

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -28,6 +28,7 @@
     "it": false,
     "jasmine": false,
     "waitsFor": false,
-    "runs": false
+    "runs": false,
+    "Symbol": false
   }
 }

--- a/test/method-factory-test.js
+++ b/test/method-factory-test.js
@@ -1,0 +1,42 @@
+"use strict";
+
+define(['test/test-helpers'], function(testHelpers) {
+    var it = testHelpers.itWithFreshLog;
+
+    describe("Setting the methodFactory tests:", function() {
+
+        it("methodFactory should be called once for each loggable level", function(log) {
+            log.methodFactory = jasmine.createSpy("methodFactory");
+
+            log.setLevel("trace");
+            expect(log.methodFactory.calls.length).toEqual(5);
+            expect(log.methodFactory.argsForCall[0]).toEqual(["trace", 0, undefined]);
+            expect(log.methodFactory.argsForCall[1]).toEqual(["debug", 0, undefined]);
+            expect(log.methodFactory.argsForCall[2]).toEqual(["info",  0, undefined]);
+            expect(log.methodFactory.argsForCall[3]).toEqual(["warn",  0, undefined]);
+            expect(log.methodFactory.argsForCall[4]).toEqual(["error", 0, undefined]);
+
+            log.setLevel("error");
+            expect(log.methodFactory.calls.length).toEqual(6);
+            expect(log.methodFactory.argsForCall[5]).toEqual(["error", 4, undefined]);
+        });
+
+        it("functions returned by methodFactory should be used as logging functions", function(log) {
+            var logFunction = function() {};
+            log.methodFactory = function() { return logFunction; };
+            log.setLevel("error");
+
+            expect(log.warn).not.toEqual(logFunction);
+            expect(log.error).toEqual(logFunction);
+        });
+
+        it("the third argument should be logger's name", function(log) {
+            var logger = log.getLogger("newLogger");
+            logger.methodFactory = jasmine.createSpy("methodFactory");
+
+            logger.setLevel("error");
+            expect(logger.methodFactory.argsForCall[0]).toEqual(["error", 4, "newLogger"]);
+        });
+
+    });
+});

--- a/test/multiple-logger-test.js
+++ b/test/multiple-logger-test.js
@@ -1,12 +1,15 @@
 "use strict";
 
-define(['../lib/loglevel'], function(log) {
+define(['test/test-helpers'], function(testHelpers) {
+    var describeIf = testHelpers.describeIf;
+    var it = testHelpers.itWithFreshLog;
+
     var originalConsole = window.console;
 
     describe("Multiple logger instances tests:", function() {
 
         describe("log.getLogger()", function() {
-            it("returns a new logger that is not the default one", function() {
+            it("returns a new logger that is not the default one", function(log) {
                 var newLogger = log.getLogger("newLogger");
                 expect(newLogger).not.toEqual(log);
                 expect(newLogger.trace).toBeDefined();
@@ -21,12 +24,61 @@ define(['../lib/loglevel'], function(log) {
                 expect(newLogger.methodFactory).toBeDefined();
             });
 
-            it("returns loggers without `getLogger()` and `noConflict()`", function() {
+            it("returns loggers without `getLogger()` and `noConflict()`", function(log) {
                 var newLogger = log.getLogger("newLogger");
                 expect(newLogger.getLogger).toBeUndefined();
                 expect(newLogger.noConflict).toBeUndefined();
             });
-            
+
+            it("returns the same instance when called repeatedly with the same name", function(log) {
+                var logger1 = log.getLogger("newLogger");
+                var logger2 = log.getLogger("newLogger");
+
+                console.log("Logger: ", logger1);
+
+                expect(logger1).toEqual(logger2);
+            });
+
+            it("should throw if called with no name", function(log) {
+                expect(function() {
+                  log.getLogger();
+                }).toThrow();
+            });
+
+            it("should throw if called with a non-string name", function(log) {
+                expect(function() {
+                  log.getLogger(true);
+                }).toThrow();
+            });
+        });
+
+        describe("inheritance", function() {
+            beforeEach(function() {
+                window.console = {"log" : jasmine.createSpy("console.log")};
+                this.addMatchers({
+                    "toBeAtLevel" : testHelpers.toBeAtLevel
+                });
+                testHelpers.clearStoredLevels();
+            });
+
+            afterEach(function() {
+                window.console = originalConsole;
+            });
+
+            it("loggers are created with the same level as the default logger", function(log) {
+              log.setLevel("ERROR", false);
+              var newLogger = log.getLogger("newLogger");
+              expect(newLogger).toBeAtLevel("error");
+            });
+
+            it("loggers are created with the same methodFactory as the default logger", function(log) {
+                log.methodFactory = function(methodName, level) {
+                  return function() {};
+                };
+
+                var newLogger = log.getLogger("newLogger");
+                expect(newLogger.methodFactory).toEqual(log.methodFactory);
+            });
         });
     });
 });

--- a/test/multiple-logger-test.js
+++ b/test/multiple-logger-test.js
@@ -1,0 +1,32 @@
+"use strict";
+
+define(['../lib/loglevel'], function(log) {
+    var originalConsole = window.console;
+
+    describe("Multiple logger instances tests:", function() {
+
+        describe("log.getLogger()", function() {
+            it("returns a new logger that is not the default one", function() {
+                var newLogger = log.getLogger("newLogger");
+                expect(newLogger).not.toEqual(log);
+                expect(newLogger.trace).toBeDefined();
+                expect(newLogger.debug).toBeDefined();
+                expect(newLogger.info).toBeDefined();
+                expect(newLogger.warn).toBeDefined();
+                expect(newLogger.error).toBeDefined();
+                expect(newLogger.setLevel).toBeDefined();
+                expect(newLogger.setDefaultLevel).toBeDefined();
+                expect(newLogger.enableAll).toBeDefined();
+                expect(newLogger.disableAll).toBeDefined();
+                expect(newLogger.methodFactory).toBeDefined();
+            });
+
+            it("returns loggers without `getLogger()` and `noConflict()`", function() {
+                var newLogger = log.getLogger("newLogger");
+                expect(newLogger.getLogger).toBeUndefined();
+                expect(newLogger.noConflict).toBeUndefined();
+            });
+            
+        });
+    });
+});

--- a/test/multiple-logger-test.js
+++ b/test/multiple-logger-test.js
@@ -58,9 +58,7 @@ define(['test/test-helpers'], function(testHelpers) {
                 expect(function() { log.getLogger(null); }).toThrow();
                 expect(function() { log.getLogger(undefined); }).toThrow();
                 if (window.Symbol) {
-                    // NOTE: still need to use window to create a symbol
-                    // because JSHint doesn't yet support symbols.
-                    expect(function() { log.getLogger(window.Symbol()); }).toThrow();
+                    expect(function() { log.getLogger(Symbol()); }).toThrow();
                 }
             });
         });

--- a/test/test-qunit.js
+++ b/test/test-qunit.js
@@ -33,11 +33,19 @@ test('basic test', function() {
     ok(typeof logging.setDefaultLevel === "function", "setDefaultLevel is a function");
     ok(typeof logging.enableAll === "function", "enableAll is a function");
     ok(typeof logging.disableAll === "function", "disableAll is a function");
-   
+    ok(typeof logging.getLogger === "function", "getLogger is a function");
+
     // Use the API to make sure it doesn't blantantly fail with exceptions
     logging.trace("a trace message");
     logging.debug("a debug message");
     logging.info("an info message");
     logging.warn("a warn message");
     logging.error("an error message");
+
+    var newLogger = logging.getLogger("newLogger");
+    newLogger.trace("a trace message");
+    newLogger.debug("a debug message");
+    newLogger.info("an info message");
+    newLogger.warn("a warn message");
+    newLogger.error("an error message");
 });


### PR DESCRIPTION
This is a simplistic implementation of #68 with minimal changes to the actual codebase (it looks a bit bigger than it really is because many methods moved into the logger constructor).

For the most part, all this ultimately does is add a method named `getLogger(name)` to the library. That method returns a new logger with the given name, or, if it’s already been called with that name, returns the previously created logger. The library itself is actually just an instance of one of these loggers, but it has the `getLogger()` and `noConflict()` methods sprinkled on top.

There are a couple ugly things in here, mostly pertaining to the discussion of inheritance: https://github.com/pimterry/loglevel/issues/68#issuecomment-120677667

- There’s a private variable named `defaultLoggerLevel` that tracks the current level of the default logger so it can be passed to new loggers. This would be better handled if logger instances had a `getLevel()` method, which would also solve #70 / fit with #77 

- There’s a little nuttiness with some private methods needing to be called with `.call()`. This is really because `methodFactory` needs to not be tightly bound to an instance in order for it to be passed along to new loggers. Maybe all private methods should be this way? Maybe some more rewriting would be in order, or a changed signature for `methodFactory`, or something related to having setters for `methodFacotry` (as noted in https://github.com/pimterry/loglevel/issues/70#issuecomment-121411810) would help. Haven’t thought too deeply here yet.