### PR TITLE
Switch order of module pattern checks for more consistent UMD.

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -7,7 +7,7 @@
 (function (root, definition) {
     "use strict";
     if (typeof define === 'function' && define.amd) {
-        define('loglevel',definition);
+        define(definition);
     } else if (typeof module === 'object' && module.exports) {
         module.exports = definition();
     } else {

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -6,10 +6,10 @@
 */
 (function (root, definition) {
     "use strict";
-    if (typeof module === 'object' && module.exports && typeof require === 'function') {
+    if (typeof define === 'function' && define.amd) {
+        define('loglevel',definition);
+    } else if (typeof module === 'object' && module.exports) {
         module.exports = definition();
-    } else if (typeof define === 'function' && typeof define.amd === 'object') {
-        define(definition);
     } else {
         root.log = definition();
     }


### PR DESCRIPTION
I was having errors thrown bundling loglevel in a library that was then being bundled in an application package and found that reversing these checks solves the issue for us.

Based on this conversation: https://github.com/umdjs/umd/pull/22 it seems that checking for AMD before CommonJS is a safer paradigm to follow.