### PR TITLE
Add `log.getLoggers()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,21 @@ The loglevel API is extremely minimal. All methods are available on the root log
 
   Likewise, loggers will inherit the root logger’s `methodFactory`. After creation, each logger can have its `methodFactory` independently set. See the *plugins* section below for more about `methodFactory`.
 
+* A `log.getLoggers()` method.
+
+  This returns a list of all the named loggers which have been created with `log.getLogger()`. The root logger is not included in this list.
+
+  ```javascript
+  var log = require("loglevel");
+
+  // Create a few loggers
+  log.getLogger("logger1");
+  log.getLogger("logger2");
+
+  // Returns '["logger1", "logger2"]'
+  log.getLoggers();
+  ```
+
 
 ## Plugins
 

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -208,6 +208,10 @@
         return logger;
     };
 
+    defaultLogger.getLoggers = function getLoggers() {
+      return Object.keys(_loggersByName);
+    };
+
     // Grab the current global log variable in case of overwrite
     var _log = (typeof window !== undefinedType) ? window.log : undefined;
     defaultLogger.noConflict = function() {

--- a/test/multiple-logger-test.js
+++ b/test/multiple-logger-test.js
@@ -63,6 +63,21 @@ define(['test/test-helpers'], function(testHelpers) {
             });
         });
 
+        describe("log.getLoggers()", function() {
+          it("returns an empty list initially", function(log) {
+            expect(log.getLoggers()).toEqual([]);
+          });
+
+          it("returns a list of existing loggers", function(log) {
+            log.getLogger("logger1");
+            log.getLogger("logger2");
+            expect(log.getLoggers()).toEqual([
+              "logger1",
+              "logger2"
+            ]);
+          });
+        });
+
         describe("inheritance", function() {
             beforeEach(function() {
                 window.console = {"log" : jasmine.createSpy("console.log")};


### PR DESCRIPTION
New API method for returning a list of all the named loggers created
with `log.getLogger()`.

This may be useful if the number of sub-loggers grow very large or if
the application dynamically creates loggers.

This pull request is a simple implementation of #93. I've not read up on the compatibility goals for loglevel, but `Object.keys` can easily be exchanged for something else for better compatibility across older interpreter implementations.