### PR TITLE
Change ES6 import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ log.error("too easy");
 ### As an ES6 module (assuming some transpilation step):
 
 ```javascript
-import * as log from 'loglevel';
+import log from 'loglevel';
 log.debug("all done");
 ```
 


### PR DESCRIPTION
I would propose to change the es6 import as done in this PR. It practically works exactly the same then, except for one crucial difference: If imported this way the references will be updated when changing the log level using `setLevel` at runtime. It took me some time to realize that the way the methods have been imported were the issue. Using `*` seems to be resulting in a separate reference, which doesn't care about the [`replaceLoggingMethods` method](https://github.com/pimterry/loglevel/blob/master/lib/loglevel.js#L68).