### PR TITLE
Add getLoggers method and save name of loggers on instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ The loglevel API is extremely minimal. All methods are available on the root log
 
   Likewise, loggers will inherit the root logger’s `methodFactory`. After creation, each logger can have its `methodFactory` independently set. See the *plugins* section below for more about `methodFactory`.
 
+* A `log.getLoggers()` method.
+
+  This will return you the dictionary of all loggers created with `getLogger`, keyed off of their names.
 
 ## Plugins
 

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -158,6 +158,8 @@
        *
        */
 
+      self.name = name;
+
       self.levels = { "TRACE": 0, "DEBUG": 1, "INFO": 2, "WARN": 3,
           "ERROR": 4, "SILENT": 5};
 

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -242,5 +242,9 @@
         return defaultLogger;
     };
 
+    defaultLogger.getLoggers = function getLoggers() {
+        return _loggersByName;
+    };
+
     return defaultLogger;
 }));


### PR DESCRIPTION
Hi! Tidy little lib, but I wanted to be able to generate a list of all my loggers so the user can select the level for each logger themselves. This was all I needed to do that.