### PR TITLE
Add logger.log() type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,13 @@ declare namespace log {
         debug(...msg: any[]): void;
 
         /**
+         * Output debug message to console including appropriate icons
+         *
+         * @param msg any data to log to the console
+         */
+        log(...msg: any[]): void;
+
+        /**
          * Output info message to console including appropriate icons
          *
          * @param msg any data to log to the console


### PR DESCRIPTION
I am using `loglevel` in a project with TypeScript, and wanted to migrate my `console.log` calls to `log.log` calls. It didn't compile because the `Logger` interface was missing the `log` function type. I added it, and it fixed my issue.