### PR TITLE
[Feature]: Add formatted Suffix

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -1,9 +1,4 @@
-/*
-* loglevel - https://github.com/pimterry/loglevel
-*
-* Copyright (c) 2013 Tim Perry
-* Licensed under the MIT license.
-*/
+/*! loglevel - v1.7.1 - https://github.com/pimterry/loglevel - (c) 2020 Tim Perry - licensed MIT */
 (function (root, definition) {
     "use strict";
     if (typeof define === 'function' && define.amd) {
@@ -32,10 +27,10 @@
     ];
 
     // Cross-browser bind equivalent that works at least back to IE6
-    function bindMethod(obj, methodName) {
+    function bindMethod(obj, methodName,prefix) {
         var method = obj[methodName];
         if (typeof method.bind === 'function') {
-            return method.bind(obj);
+            return method.bind(obj, `[${methodName.toUpperCase()}]`, prefix);
         } else {
             try {
                 return Function.prototype.bind.call(method, obj);
@@ -63,7 +58,7 @@
 
     // Build the best logging method possible for this env
     // Wherever possible we want to bind, not wrap, to preserve stack traces
-    function realMethod(methodName) {
+    function realMethod(methodName,prefix) {
         if (methodName === 'debug') {
             methodName = 'log';
         }
@@ -73,7 +68,7 @@
         } else if (methodName === 'trace' && isIE) {
             return traceForIE;
         } else if (console[methodName] !== undefined) {
-            return bindMethod(console, methodName);
+            return bindMethod(console, methodName, prefix, methodName);
         } else if (console.log !== undefined) {
             return bindMethod(console, 'log');
         } else {
@@ -83,13 +78,13 @@
 
     // These private functions always need `this` to be set properly
 
-    function replaceLoggingMethods(level, loggerName) {
+    function replaceLoggingMethods(level, prefix) {
         /*jshint validthis:true */
         for (var i = 0; i < logMethods.length; i++) {
             var methodName = logMethods[i];
             this[methodName] = (i < level) ?
                 noop :
-                this.methodFactory(methodName, level, loggerName);
+                this.methodFactory(methodName, level, prefix);
         }
 
         // Define log.log as an alias for log.debug
@@ -98,10 +93,10 @@
 
     // In old IE versions, the console isn't present until you first open it.
     // We build realMethod() replacements here that regenerate logging methods
-    function enableLoggingWhenConsoleArrives(methodName, level, loggerName) {
+    function enableLoggingWhenConsoleArrives(methodName, level, prefix) {
         return function () {
             if (typeof console !== undefinedType) {
-                replaceLoggingMethods.call(this, level, loggerName);
+                replaceLoggingMethods.call(this, level, prefix);
                 this[methodName].apply(this, arguments);
             }
         };
@@ -109,9 +104,9 @@
 
     // By default, we use closely bound real methods wherever possible, and
     // otherwise we wait for a console to appear, and then try again.
-    function defaultMethodFactory(methodName, level, loggerName) {
+    function defaultMethodFactory(methodName, level, prefix) {
         /*jshint validthis:true */
-        return realMethod(methodName) ||
+        return realMethod(methodName, prefix) ||
                enableLoggingWhenConsoleArrives.apply(this, arguments);
     }
 
@@ -189,7 +184,13 @@
       self.getLevel = function () {
           return currentLevel;
       };
-
+      self.setPrefix = function(prefix) {
+	   self.prefix = prefix;
+	   replaceLoggingMethods.call(self, self.level, self.prefix() || name.toUpperCase() || "");
+              if (typeof console === undefinedType && level < self.levels.SILENT) {
+                  return "No console available for logging";
+              }
+      }
       self.setLevel = function (level, persist) {
           if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
               level = self.levels[level.toUpperCase()];
@@ -199,7 +200,8 @@
               if (persist !== false) {  // defaults to true
                   persistLevelIfPossible(level);
               }
-              replaceLoggingMethods.call(self, level, name);
+	      
+              replaceLoggingMethods.call(self, level,  (name || "").toUpperCase());
               if (typeof console === undefinedType && level < self.levels.SILENT) {
                   return "No console available for logging";
               }

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -186,10 +186,13 @@
       };
       self.setPrefix = function(prefix) {
 	   self.prefix = prefix;
-	   replaceLoggingMethods.call(self, self.level, self.prefix() || name.toUpperCase() || "");
-              if (typeof console === undefinedType && level < self.levels.SILENT) {
+	   if (typeof self.prefix === "function")
+		   replaceLoggingMethods.call(self, self.level, self.prefix() || name.toUpperCase() || "");
+	   else 
+                  replaceLoggingMethods.call(self, self.level, self.prefix || name.toUpperCase() || "");
+           if (typeof console === undefinedType && level < self.levels.SILENT) {
                   return "No console available for logging";
-              }
+           }
       }
       self.setLevel = function (level, persist) {
           if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {


### PR DESCRIPTION
* Modification in order to add suffix to logging without loss console log main functionality such as tracing:

Basic example:

```js

const  socketLog = logger.getLogger('socketLog');
socketLog.setPrefix("[SocketLog]");
socketLog.info("test");

```
Formating text:

```js
const  socketLog = logger.getLogger('socketLog');
chicken.setPrefix(formating.bind(socketLog,"socketLog"));
socketLog.info("test");
function formating(name){ 
   return  new Date().toTimeString().replace(/.*(\d{2}:\d{2}:\d{2}).*/, '$1') + `(${name || this.name})`
}
```