### PR TITLE
Allow the persistent storage to be cleared

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ The loglevel API is extremely minimal. All methods are available on the root log
   * As a string, like 'error' (case-insensitive) ← _for a reasonable practical balance_
   * As a numeric index from 0 (trace) to 5 (silent) ← _deliciously terse, and more easily programmable (...although, why?)_
 
-  Where possible the log level will be persisted. LocalStorage will be used if available, falling back to cookies if not. If neither is available in the current environment (i.e. in Node), or if you pass `false` as the optional 'persist' second argument, persistence will be skipped.
+  Where possible the log level will be persisted. LocalStorage will be used if available, falling back to cookies if not. If neither is available in the current environment (i.e. in Node), or if you pass `false` as the optional 'persist' second argument, persistence will be skipped. If you pass `{ reset: true }` as the optional 'persist' second argument, the persisted level will be
+  cleared (causing future log.setDefaultLevel() calls to fall back to the default level).
 
   If log.setLevel() is called when a console object is not available (in IE 8 or 9 before the developer tools have been opened, for example) logging will remain silent until the console becomes available, and then begin logging at the requested level.
 

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -173,6 +173,22 @@
           return storedLevel;
       }
 
+      function clearPersistedLevel() {
+          if (typeof window === undefinedType || !storageKey) return;
+
+          // Use localStorage if available
+          try {
+              window.localStorage.removeItem(storageKey);
+              return;
+          } catch (ignore) {}
+
+          // Use session cookie as fallback
+          try {
+              window.document.cookie =
+                encodeURIComponent(storageKey) + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+          } catch (ignore) {}
+      }
+
       /*
        *
        * Public logger API - see https://github.com/pimterry/loglevel for details
@@ -197,7 +213,11 @@
           if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
               currentLevel = level;
               if (persist !== false) {  // defaults to true
+                if(typeof persist === 'object' && persist.reset) {
+                  clearPersistedLevel();
+                } else {
                   persistLevelIfPossible(level);
+                }
               }
               replaceLoggingMethods.call(self, level, name);
               if (typeof console === undefinedType && level < self.levels.SILENT) {

--- a/test/local-storage-test.js
+++ b/test/local-storage-test.js
@@ -96,6 +96,14 @@ define(['test/test-helpers'], function(testHelpers) {
                 expect("info").toBeTheStoredLevel();
                 expect("error").not.toBeTheStoredLevel();
             });
+
+            it("log.setLevel() clears the saved level if `persist` argument is `{ reset: true }`", function(log) {
+                log.setLevel("error", { reset: true });
+
+                expect(undefined).toBeTheStoredLevel();
+                expect("info").not.toBeTheStoredLevel();
+                expect("error").not.toBeTheStoredLevel();
+            });
         });
 
         describe("If warn level is saved", function () {

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -67,10 +67,12 @@ define(function () {
     };
 
     self.toBeTheLevelStoredByCookie = function toBeTheLevelStoredByCookie(name) {
-        var level = this.actual.toUpperCase();
+        var level = this.actual === undefined ? undefined : this.actual.toUpperCase();
         var storageKey = encodeURIComponent(getStorageKey(name));
 
-        if (window.document.cookie.indexOf(storageKey + "=" + level) !== -1) {
+        if(level === undefined) {
+            return window.document.cookie.indexOf(storageKey + "=") === -1;
+        } else if (window.document.cookie.indexOf(storageKey + "=" + level) !== -1) {
             return true;
         } else {
             return false;
@@ -78,7 +80,7 @@ define(function () {
     };
 
     self.toBeTheLevelStoredByLocalStorage = function toBeTheLevelStoredByLocalStorage(name) {
-        var level = this.actual.toUpperCase();
+        var level = this.actual === undefined ? undefined : this.actual.toUpperCase();
 
         if (window.localStorage[getStorageKey(name)] === level) {
             return true;


### PR DESCRIPTION
This PR adds an optional `{ reset: true }` persist argument value for `setLevel`. This can be used when resetting a log level back to the default state, so that future page loads will fall back to the default log level. This both reduces the clutter in Local Storage and allows people who aren't actively wanting a specific log level to get new default log levels in the (probably unlikely) event the default level is increased or decreased.

In our case, we have a large number of loggers, all of which currently defaults to WARN level. It is not uncommon for someone to want to change a few individual loggers to INFO or DEBUG level to test something or help diagnose an issue, and then reset them back to the default.
This means developers can easily end up with dozens of `loglevel:name` entries in their Local Storage all set to `WARN`, making it harder to find actually useful Local Storage entries.