### PR TITLE
Added resetLevel method

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ The loglevel API is extremely minimal. All methods are available on the root log
 
   The `level` argument takes is the same values that you might pass to `setLevel()`. Levels set using `setDefaultLevel()` never persist to subsequent page loads.
 
+* A `log.resetLevel()` method.
+
+  This resets the current log level to the default level (or `warn` if no explicit default was set) and clears the persisted level if one was previously persisted.
+
 * `log.enableAll()` and `log.disableAll()` methods.
 
   These enable or disable all log messages, and are equivalent to log.setLevel("trace") and log.setLevel("silent") respectively.

--- a/index.d.ts
+++ b/index.d.ts
@@ -168,6 +168,12 @@ declare namespace log {
         setDefaultLevel(level: LogLevelDesc): void;
 
         /**
+         * This resets the current log level to the default level (or `warn` if no explicit default was set) and clears
+         * the persisted level if one was previously persisted.
+         */
+        resetLevel(): void;
+
+        /**
          * This enables all log messages, and is equivalent to log.setLevel("trace").
          *
          * @param persist Where possible the log level will be persisted. LocalStorage will be used if available, falling

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -118,6 +118,7 @@
     function Logger(name, defaultLevel, factory) {
       var self = this;
       var currentLevel;
+      defaultLevel = defaultLevel == null ? "WARN" : defaultLevel;
 
       var storageKey = "loglevel";
       if (typeof name === "string") {
@@ -173,6 +174,22 @@
           return storedLevel;
       }
 
+      function clearPersistedLevel() {
+          if (typeof window === undefinedType || !storageKey) return;
+
+          // Use localStorage if available
+          try {
+              window.localStorage.removeItem(storageKey);
+              return;
+          } catch (ignore) {}
+
+          // Use session cookie as fallback
+          try {
+              window.document.cookie =
+                encodeURIComponent(storageKey) + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+          } catch (ignore) {}
+      }
+
       /*
        *
        * Public logger API - see https://github.com/pimterry/loglevel for details
@@ -209,9 +226,15 @@
       };
 
       self.setDefaultLevel = function (level) {
+          defaultLevel = level;
           if (!getPersistedLevel()) {
               self.setLevel(level, false);
           }
+      };
+
+      self.resetLevel = function () {
+          self.setLevel(defaultLevel, false);
+          clearPersistedLevel();
       };
 
       self.enableAll = function(persist) {
@@ -225,7 +248,7 @@
       // Initialize with the right level
       var initialLevel = getPersistedLevel();
       if (initialLevel == null) {
-          initialLevel = defaultLevel == null ? "WARN" : defaultLevel;
+          initialLevel = defaultLevel;
       }
       self.setLevel(initialLevel, false);
     }

--- a/test/default-level-test.js
+++ b/test/default-level-test.js
@@ -56,5 +56,22 @@ define(['test/test-helpers'], function(testHelpers) {
                 expect("debug").not.toBeTheStoredLevel();
             });
         });
+
+        describe("log.resetLevel() resets the log", function() {
+            it("to warn if no explicit default is set", function(log) {
+                log.setLevel("debug");
+                log.resetLevel();
+
+                expect(log).toBeAtLevel("warn");
+            });
+
+            it("to info if default is set to info", function(log) {
+                log.setDefaultLevel("info");
+                log.setLevel("debug");
+                log.resetLevel();
+
+                expect(log).toBeAtLevel("info");
+            });
+        });
     });
 });

--- a/test/local-storage-test.js
+++ b/test/local-storage-test.js
@@ -96,6 +96,13 @@ define(['test/test-helpers'], function(testHelpers) {
                 expect("info").toBeTheStoredLevel();
                 expect("error").not.toBeTheStoredLevel();
             });
+
+            it("log.resetLevel() clears the saved level", function(log) {
+                log.resetLevel();
+
+                expect(undefined).toBeTheStoredLevel();
+                expect("info").not.toBeTheStoredLevel();
+            });
         });
 
         describe("If warn level is saved", function () {

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -67,10 +67,12 @@ define(function () {
     };
 
     self.toBeTheLevelStoredByCookie = function toBeTheLevelStoredByCookie(name) {
-        var level = this.actual.toUpperCase();
+        var level = this.actual === undefined ? undefined : this.actual.toUpperCase();
         var storageKey = encodeURIComponent(getStorageKey(name));
 
-        if (window.document.cookie.indexOf(storageKey + "=" + level) !== -1) {
+        if(level === undefined) {
+            return window.document.cookie.indexOf(storageKey + "=") === -1;
+        } else if (window.document.cookie.indexOf(storageKey + "=" + level) !== -1) {
             return true;
         } else {
             return false;
@@ -78,7 +80,7 @@ define(function () {
     };
 
     self.toBeTheLevelStoredByLocalStorage = function toBeTheLevelStoredByLocalStorage(name) {
-        var level = this.actual.toUpperCase();
+        var level = this.actual === undefined ? undefined : this.actual.toUpperCase();
 
         if (window.localStorage[getStorageKey(name)] === level) {
             return true;


### PR DESCRIPTION
This provides a `resetLevel()` method as an alternative solution to the use cases detailed in #172