### PR TITLE
fix: methodFactory type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,18 +28,18 @@ declare namespace log {
     /**
      * Possible log level descriptors, may be string, lower or upper case, or number.
      */
-    type LogLevelDesc = LogLevelNumbers
+    type LogLevelDesc = LogLevelNumbers | LogLevelNames | 'silent' | keyof LogLevel;
+
+    type LogLevelNames =
         | 'trace'
         | 'debug'
         | 'info'
         | 'warn'
-        | 'error'
-        | 'silent'
-        | keyof LogLevel;
+        | 'error';
 
     type LoggingMethod = (...message: any[]) => void;
 
-    type MethodFactory = (methodName: string, level: LogLevelNumbers, loggerName: string | symbol) => LoggingMethod;
+    type MethodFactory = (methodName: LogLevelNames, level: LogLevelNumbers, loggerName: string | symbol) => LoggingMethod;
 
     interface RootLogger extends Logger {
         /**


### PR DESCRIPTION
After investigating the type and the code, I found out that the `methodFactory` type was too permissive.

`methodFactory` is called only for the list of defined methods (from `trace` to `error`).

This commit does not change the javascript logic, only the type definition.

ℹ️ breaking: only in typescript type definition (so only compile-time, not runtime)