### PR TITLE
Created a demo page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+    <head>
+        <meta charset="utf-8" />
+        <title>loglevel Demo</title>
+        <meta
+            name="description"
+            content="A demo to show the features of loglevel."
+        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="styles.css" />
+        <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@48,600,0,0"
+        />
+    </head>
+    <main>
+        <h1>loglevel Demo</h1>
+        <form id="LogForm" class="code-container">
+            <code>
+                log.
+                <select name="logLevel" aria-label="Log type" required>
+                    <option value="trace">trace</option>
+                    <option value="debug">debug</option>
+                    <option value="info">info</option>
+                    <option value="warn">warn</option>
+                    <option value="error">error</option>
+                </select>
+                ("
+                <input
+                    name="debugMessage"
+                    type="text"
+                    placeholder="Log text"
+                    aria-label="Log text"
+                    required
+                />
+                ")
+            </code>
+            <button type="submit">Run</button>
+            <details>
+                <summary>More information...</summary>
+                Choose your level of logging and enter some text to output it to the console using logLevel.
+                <a href="https://github.com/pimterry/loglevel#logging-methods">Documentation for logging methods.</a>
+            </details>
+        </form>
+        <form id="SetLevel" class="code-container">
+            <code>
+                log.setLevel("
+                <select name="level" aria-label="Log type" required>
+                    <option value="0">trace</option>
+                    <option value="1">debug</option>
+                    <option value="2">info</option>
+                    <option value="3">warn</option>
+                    <option value="4">error</option>
+                    <option value="5">silent</option>
+                </select>
+                ",
+                <select name="persist" aria-label="Log type" required>
+                    <option value="true">true</option>
+                    <option value="false">false</option>
+                </select>
+                )
+            </code>
+            <button type="submit">Run</button>
+            <details>
+                <summary>More information...</summary>
+                Disable all logging below the given level.
+                <a href="https://github.com/pimterry/loglevel#logsetlevellevel-persist">Documentation for setLevel().</a>
+            </details>
+        </form>
+        <form id="SetDefaultLevel" class="code-container">
+            <code>
+                log.setDefaultLevel("
+                <select name="level" aria-label="Log type" required>
+                    <option value="0">trace</option>
+                    <option value="1">debug</option>
+                    <option value="2">info</option>
+                    <option value="3">warn</option>
+                    <option value="4">error</option>
+                    <option value="5">silent</option>
+                </select>
+                ")
+            </code>
+            <button type="submit">Run</button>
+            <details>
+                <summary>More information...</summary>
+                Select a level and run to set the default logging level.
+                <a href="https://github.com/pimterry/loglevel#logsetdefaultlevellevel">Documentation for setDefaultLevel().</a>
+            </details>
+        </form>
+        <div class="code-container">
+            <code>
+                log.resetLevel()
+            </code>
+            <button id="ResetLevelButton" type="button">Run</button>
+            <details>
+                <summary>More information...</summary>
+                Reset the current logging level to default.
+                <a href="https://github.com/pimterry/loglevel#logresetlevel">Documentation for resetLevel().</a>
+            </details>
+        </div>
+        <div class="code-container">
+            <code>
+                log.enableAll()
+            </code>
+            <button id="EnableAllButton" type="button">Run</button>
+            <details>
+                <summary>More information...</summary>
+                Enables all logs - equivalent of <code>setLevel('trace')</code>.
+                <a href="https://github.com/pimterry/loglevel##logenableall-and-logdisableall">Documentation for enableAll().</a>
+            </details>
+        </div>
+        <div class="code-container">
+            <code>
+                log.disableAll()
+            </code>
+            <button id="DisableAllButton" type="button">Run</button>
+            <details>
+                <summary>More information...</summary>
+                Disables all logs - equivalent of <code>setLevel('silent')</code>.
+                <a href="https://github.com/pimterry/loglevel##logenableall-and-logdisableall">Documentation for disableAll().</a>
+            </details>
+        </div>
+        <h2>Log State</h2>
+        <div id="LogState" class="code-container">
+            <label>
+                Current log level
+                <input name="currentLevel" aria-label="Current log level" readonly>
+            </label>
+            <details>
+                <summary>More information...</summary>
+                Uses the <code>getLevel()</code> method to display the current log level.
+                <a href="https://github.com/pimterry/loglevel##logenableall-and-logdisableall">Documentation for disableAll().</a>
+            </details>
+        </div>
+    </main>
+    <script src="../dist/loglevel.js"></script>
+    <script src="script.js"></script>
+</html>

--- a/demo/script.js
+++ b/demo/script.js
@@ -1,0 +1,86 @@
+document.addEventListener('DOMContentLoaded', () => {
+    log.setDefaultLevel(log.levels.TRACE, false);
+
+    const demoForm = document.getElementById('LogForm');
+    const setLevelForm = document.getElementById('SetLevel');
+    const setDefaultLevelForm = document.getElementById('SetDefaultLevel');
+    const resetLevelButton = document.getElementById('ResetLevelButton');
+    const enableAllButton = document.getElementById('EnableAllButton');
+    const disableAllButton = document.getElementById('DisableAllButton');
+
+    if (demoForm) {
+        demoForm.addEventListener('submit', onSubmitDemoForm);
+    }
+
+    if (setLevelForm) {
+        setLevelForm.addEventListener('submit', onSubmitSetLevelForm);
+    }
+
+    if (setDefaultLevelForm) {
+        setDefaultLevelForm.addEventListener('submit', onSubmitSetDefaultLevelForm);
+    }
+
+    if (resetLevelButton) {
+        resetLevelButton.addEventListener('click', () => {
+            log.resetLevel();
+            updateLogStateForm();
+        });
+    }
+
+    if (enableAllButton) {
+        enableAllButton.addEventListener('click', () => {
+            log.enableAll();
+            updateLogStateForm();
+        });
+    }
+
+    if (disableAllButton) {
+        disableAllButton.addEventListener('click', () => {
+            log.disableAll();
+            updateLogStateForm();
+        });
+    }
+
+    updateLogStateForm();
+});
+
+function onSubmitDemoForm(event) {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    const formData = new FormData(form)
+    const debugMessage = formData.get('debugMessage');
+    const logLevel = formData.get('logLevel');
+
+    if (debugMessage && logLevel) {
+        log[logLevel](debugMessage);
+    }
+}
+
+function onSubmitSetLevelForm(event) {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    const formData = new FormData(form)
+    log.setLevel(parseInt(formData.get('level')), formData.get('persist') === 'true');
+    updateLogStateForm();
+}
+
+function onSubmitSetDefaultLevelForm(event) {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    const formData = new FormData(form)
+    log.setDefaultLevel(parseInt(formData.get('level')));
+    updateLogStateForm();
+}
+
+function updateLogStateForm() {
+    const logState = document.getElementById('LogState');
+
+    if (logState) {
+        const currentLevel = logState.querySelector('input[name="currentLevel"]');
+        const logLevel = log.getLevel();
+        currentLevel.value = Object.keys(log.levels).find(key => log.levels[key] === logLevel);
+    }
+}

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -1,0 +1,107 @@
+* {
+    box-sizing: border-box;
+    font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    color: #161230;
+}
+
+body {
+    font-size: 18px;
+    background-color: #fafafa;
+}
+
+main {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+}
+
+form {
+}
+
+label {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+}
+
+input,
+select,
+button {
+    /* flex-grow: 1; */
+    font-size: 1rem;
+    padding: 0.25rem;
+    border: 1px solid;
+    border-radius: 4px;
+}
+
+input[type="checkbox"] {
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+button {
+    cursor: pointer;
+    align-self: center;
+    padding: 0.5rem 1.5rem;
+    background-color: #161230;
+    color: #fafafa;
+    font-size: 1.5rem;
+}
+
+summary {
+    cursor: pointer;
+}
+
+code,
+code > input,
+code > select {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 1.5rem;
+}
+
+code {
+    display: flex;
+    align-items: center;
+}
+
+code input,
+code select {
+    border-color: #a9b7c9;
+}
+
+code button {
+    margin-left: 2rem;
+}
+
+details {
+    width: 100%;
+}
+
+summary {
+    margin-bottom: 0.5rem;
+}
+
+details code {
+    display: inline-block;
+    font-size: 1.1rem;
+    margin-left: 0.2rem;
+    font-weight: 600;
+}
+
+.code-container {
+    width: 80vw;
+    max-width: 800px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    border: 1px solid;
+    border-radius: 4px;
+    background-color: #eaf3ff;
+    padding: 1rem;
+    flex-wrap: wrap;
+}


### PR DESCRIPTION
As per request in #123 this contains a demo of loglevel. It is a static HTML page running some basic JS to showcase some of the features of loglevel, though it does rely on the user checking the console (understandably). I have also updated the README 'Documentation' section to have sub headings for each of the methods. This means that the demo page can link directly to the documentation where appropriate. If this goes through, I'd suggest that using a GitHub action to copy the files to GitHub pages would be the easiest way of keeping the demo with the rest of the code/docs.