### PR TITLE
Add `Logger.rebuild()` Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The `level` argument takes is the same values that you might pass to `setLevel()
 
 #### `log.resetLevel()`
 
-This resets the current log level to the default level (or `warn` if no explicit default was set) and clears the persisted level if one was previously persisted.
+This resets the current log level to the logger's default level (if no explicit default was set, then it resets it to the root logger's level, or to `WARN`) and clears the persisted level if one was previously persisted.
 
 #### `log.enableAll()` and `log.disableAll()`
 
@@ -245,13 +245,33 @@ Likewise, loggers will inherit the root logger’s `methodFactory`. After creati
 
 This will return you the dictionary of all loggers created with `getLogger`, keyed off of their names.
 
-#### `log.rebuild([includeChildren])`
+#### `log.rebuild()`
 
-Ensure the various logging methods (`log.info()`, `log.warn()`, etc.) behave as expected given the currently set logging level. Setting the `includeChildren` argument to `true` will also rebuild all child loggers of the logger this was called on.
+Ensure the various logging methods (`log.info()`, `log.warn()`, etc.) behave as expected given the currently set logging level and `methodFactory`. It will also rebuild all child loggers of the logger this was called on.
 
-This is mostly useful for plugin development. When you call `log.setLevel()` or `log.setDefaultLevel()`, this is called automatically under the hood. However, if you change the logger’s `methodFactory`, you should use this to rebuild all the logging methods with your new factory.
+This is mostly useful for plugin development. When you call `log.setLevel()` or `log.setDefaultLevel()`, the logger is rebuilt automatically. However, if you change the logger’s `methodFactory`, you should use this to rebuild all the logging methods with your new factory.
 
-If you change the level of the root logger and want it to affect other child loggers that you’ve already created (and have not called `otherChildLogger.setLevel()` on), you can do so by calling `log.rebuild(true)`.
+It is also useful if you change the level of the root logger and want it to affect child loggers that you’ve already created (and have not called `someChildLogger.setLevel()` or `someChildLogger.setDefaultLevel()` on). For example:
+
+```js
+var childLogger1 = log.getLogger("child1");
+childLogger1.getLevel();  // WARN (inherited from the root logger)
+
+var childLogger2 = log.getLogger("child2");
+childLogger2.setDefaultLevel("TRACE");
+childLogger2.getLevel();  // TRACE
+
+log.setLevel("ERROR");
+
+// At this point, the child loggers have not changed:
+childLogger1.getLevel();  // WARN
+childLogger2.getLevel();  // TRACE
+
+// To update them:
+log.rebuild();
+childLogger1.getLevel();  // ERROR (still inheriting from root logger)
+childLogger2.getLevel();  // TRACE (no longer inheriting because `.setDefaultLevel() was called`)
+```
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ If `log.setLevel()` is called when a console object is not available (in IE 8 or
 
 #### `log.setDefaultLevel(level)`
 
-This sets the current log level only if one has never been explicitly set, either via `log.setLevel()` or loaded from a previously persisted `setLevel()` call. This is useful when initializing scripts; if a developer or user has previously called `setLevel()`, this won’t alter their settings. For example, your application might set the log level to `error` in a production environment, but when debugging an issue, you might call `setLevel("trace")` on the console to see all the logs. If that `error` setting was set using `setDefaultLevel()`, it will still stay as `trace` on subsequent page loads and refreshes instead of resetting to `error`.
+This sets the current log level only if one has not been persisted and can’t be loaded. This is useful when initializing modules or scripts; if a developer or user has previously called `setLevel()`, this won’t alter their settings. For example, your application might set the log level to `error` in a production environment, but when debugging an issue, you might call `setLevel("trace")` on the console to see all the logs. If that `error` setting was set using `setDefaultLevel()`, it will still stay as `trace` on subsequent page loads and refreshes instead of resetting to `error`.
 
 The `level` argument takes is the same values that you might pass to `setLevel()`. Levels set using `setDefaultLevel()` never persist to subsequent page loads.
 

--- a/README.md
+++ b/README.md
@@ -154,21 +154,21 @@ Be aware that all this means that these method won't necessarily always produce 
 
 #### `log.setLevel(level, [persist])`
 
-This disables all logging below the given level, so that after a log.setLevel("warn") call log.warn("something") or log.error("something") will output messages, but log.info("something") will not.
+This disables all logging below the given level, so that after a `log.setLevel("warn")` call `log.warn("something")` or `log.error("something")` will output messages, but `log.info("something")` will not.
 
-This can take either a log level name or 'silent' (which disables everything) in one of a few forms:
+This can take either a log level name or `'silent'` (which disables everything) in one of a few forms:
 
-* As a log level from the internal levels list, e.g. log.levels.SILENT ← _for type safety_
-* As a string, like 'error' (case-insensitive) ← _for a reasonable practical balance_
-* As a numeric index from 0 (trace) to 5 (silent) ← _deliciously terse, and more easily programmable (...although, why?)_
+* As a log level from the internal levels list, e.g. `log.levels.SILENT` ← _for type safety_
+* As a string, like `'error'` (case-insensitive) ← _for a reasonable practical balance_
+* As a numeric index from `0` (trace) to `5` (silent) ← _deliciously terse, and more easily programmable (...although, why?)_
 
-Where possible the log level will be persisted. LocalStorage will be used if available, falling back to cookies if not. If neither is available in the current environment (i.e. in Node), or if you pass `false` as the optional 'persist' second argument, persistence will be skipped.
+Where possible, the log level will be persisted. LocalStorage will be used if available, falling back to cookies if not. If neither is available in the current environment (i.e. in Node), or if you pass `false` as the optional 'persist' second argument, persistence will be skipped.
 
-If log.setLevel() is called when a console object is not available (in IE 8 or 9 before the developer tools have been opened, for example) logging will remain silent until the console becomes available, and then begin logging at the requested level.
+If `log.setLevel()` is called when a console object is not available (in IE 8 or 9 before the developer tools have been opened, for example) logging will remain silent until the console becomes available, and then begin logging at the requested level.
 
 #### `log.setDefaultLevel(level)`
 
-This sets the current log level only if one has not been persisted and can’t be loaded. This is useful when initializing scripts; if a developer or user has previously called `setLevel()`, this won’t alter their settings. For example, your application might set the log level to `error` in a production environment, but when debugging an issue, you might call `setLevel("trace")` on the console to see all the logs. If that `error` setting was set using `setDefaultLevel()`, it will still stay as `trace` on subsequent page loads and refreshes instead of resetting to `error`.
+This sets the current log level only if one has never been explicitly set, either via `log.setLevel()` or loaded from a previously persisted `setLevel()` call. This is useful when initializing scripts; if a developer or user has previously called `setLevel()`, this won’t alter their settings. For example, your application might set the log level to `error` in a production environment, but when debugging an issue, you might call `setLevel("trace")` on the console to see all the logs. If that `error` setting was set using `setDefaultLevel()`, it will still stay as `trace` on subsequent page loads and refreshes instead of resetting to `error`.
 
 The `level` argument takes is the same values that you might pass to `setLevel()`. Levels set using `setDefaultLevel()` never persist to subsequent page loads.
 
@@ -245,6 +245,14 @@ Likewise, loggers will inherit the root logger’s `methodFactory`. After creati
 
 This will return you the dictionary of all loggers created with `getLogger`, keyed off of their names.
 
+#### `log.rebuild([includeChildren])`
+
+Ensure the various logging methods (`log.info()`, `log.warn()`, etc.) behave as expected given the currently set logging level. Setting the `includeChildren` argument to `true` will also rebuild all child loggers of the logger this was called on.
+
+This is mostly useful for plugin development. When you call `log.setLevel()` or `log.setDefaultLevel()`, this is called automatically under the hood. However, if you change the logger’s `methodFactory`, you should use this to rebuild all the logging methods with your new factory.
+
+If you change the level of the root logger and want it to affect other child loggers that you’ve already created (and have not called `otherChildLogger.setLevel()` on), you can do so by calling `log.rebuild(true)`.
+
 ## Plugins
 
 ### Existing plugins
@@ -276,7 +284,7 @@ log.methodFactory = function (methodName, logLevel, loggerName) {
         rawMethod("Newsflash: " + message);
     };
 };
-log.setLevel(log.getLevel()); // Be sure to call setLevel method in order to apply plugin
+log.rebuild(); // Be sure to call the rebuild method in order to apply plugin.
 ```
 
 *(The above supports only a single string `log.warn("...")` argument for clarity, but it's easy to extend to a [fuller variadic version](http://jsbin.com/xehoye/edit?html,console).)*

--- a/index.d.ts
+++ b/index.d.ts
@@ -190,5 +190,15 @@ declare namespace log {
          *     false as the optional 'persist' second argument, persistence will be skipped.
          */
         disableAll(persist?: boolean): void;
+
+        /**
+         * Rebuild the logging methods on this logger and optionally its child loggers.
+         *
+         * This is mostly intended for plugin developers, but can be useful if you update a logger's `methodFactory` or
+         * if you want to apply the root logger’s level to any *pre-existing* child loggers as their new default level.
+         *
+         * @param includeChildren Call `rebuild()` recursively on any child loggers of this logger.
+         */
+        rebuild(includeChildren?: boolean): void;
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -192,13 +192,12 @@ declare namespace log {
         disableAll(persist?: boolean): void;
 
         /**
-         * Rebuild the logging methods on this logger and optionally its child loggers.
+         * Rebuild the logging methods on this logger and its child loggers.
          *
          * This is mostly intended for plugin developers, but can be useful if you update a logger's `methodFactory` or
-         * if you want to apply the root logger’s level to any *pre-existing* child loggers as their new default level.
-         *
-         * @param includeChildren Call `rebuild()` recursively on any child loggers of this logger.
+         * if you want to apply the root logger’s level to any *pre-existing* child loggers (this updates the level on
+         * any child logger that hasn't used `setLevel()` or `setDefaultLevel()`).
          */
-        rebuild(includeChildren?: boolean): void;
+        rebuild(): void;
     }
 }

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -118,10 +118,30 @@
                enableLoggingWhenConsoleArrives.apply(this, arguments);
     }
 
-    function Logger(name, defaultLevel, factory) {
+    function Logger(name, factory) {
+      // Private instance variables.
       var self = this;
-      var currentLevel;
-      defaultLevel = defaultLevel == null ? "WARN" : defaultLevel;
+      /**
+       * The level inherited from a parent logger (or a global default). We
+       * cache this here rather than delegating to the parent so that it stays
+       * in sync with the actual logging methods that we have installed (the
+       * parent could change levels but we might not have rebuilt the loggers
+       * in this child yet).
+       * @type {number}
+       */
+      var inheritedLevel;
+      /**
+       * The default level for this logger, if any. If set, this overrides
+       * `inheritedLevel`.
+       * @type {number|null}
+       */
+      var defaultLevel;
+      /**
+       * A user-specific level for this logger. If set, this overrides
+       * `defaultLevel`.
+       * @type {number|null}
+       */
+      var userLevel;
 
       var storageKey = "loglevel";
       if (typeof name === "string") {
@@ -185,7 +205,6 @@
           // Use localStorage if available
           try {
               window.localStorage.removeItem(storageKey);
-              return;
           } catch (ignore) {}
 
           // Use session cookie as fallback
@@ -230,31 +249,36 @@
       self.methodFactory = factory || defaultMethodFactory;
 
       self.getLevel = function () {
-          return currentLevel == null ? defaultLevel : currentLevel;
+          if (userLevel != null) {
+            return userLevel;
+          } else if (defaultLevel != null) {
+            return defaultLevel;
+          } else {
+            return inheritedLevel;
+          }
       };
 
       self.setLevel = function (level, persist) {
-          level = normalizeLevel(level);
-          currentLevel = level;
+          userLevel = normalizeLevel(level);
           if (persist !== false) {  // defaults to true
-              persistLevelIfPossible(level);
+              persistLevelIfPossible(userLevel);
           }
-          // NOTE: in v2, this should call rebuild(), which is recursive.
+
+          // NOTE: in v2, this should call rebuild(), which updates children.
           return rebuildLoggingMethods();
       };
 
       self.setDefaultLevel = function (level) {
           defaultLevel = normalizeLevel(level);
-          if (currentLevel == null) {
-              // NOTE: in v2, this should call rebuild(), which is recursive.
-              rebuildLoggingMethods();
+          if (!getPersistedLevel()) {
+              self.setLevel(level, false);
           }
       };
 
       self.resetLevel = function () {
+          userLevel = null;
           clearPersistedLevel();
-          currentLevel = null;
-          self.setDefaultLevel(defaultLevel);
+          rebuildLoggingMethods();
       };
 
       self.enableAll = function(persist) {
@@ -266,24 +290,30 @@
       };
 
       self.rebuild = function () {
+          if (defaultLogger !== self) {
+              inheritedLevel = normalizeLevel(defaultLogger.getLevel());
+          }
           rebuildLoggingMethods();
 
           if (defaultLogger === self) {
-              var level = self.getLevel();
-
               for (var childName in _loggersByName) {
-                _loggersByName[childName].setDefaultLevel(level);
+                _loggersByName[childName].rebuild();
               }
           }
       };
 
-      // Initialize with the right level
-      var initialLevel = getPersistedLevel();
-      if (initialLevel == null) {
-          self.setDefaultLevel(defaultLevel);
-      } else {
-          self.setLevel(initialLevel, false);
+      // Initialize all the internal levels.
+      inheritedLevel = normalizeLevel(
+          defaultLogger ? defaultLogger.getLevel() : "WARN"
+      );
+      if (defaultLevel != null) {
+          defaultLevel = normalizeLevel(defaultLevel);
       }
+      var initialLevel = getPersistedLevel();
+      if (initialLevel != null) {
+          userLevel = normalizeLevel(initialLevel);
+      }
+      rebuildLoggingMethods();
     }
 
     /*
@@ -296,13 +326,15 @@
 
     defaultLogger.getLogger = function getLogger(name) {
         if ((typeof name !== "symbol" && typeof name !== "string") || name === "") {
-          throw new TypeError("You must supply a name when creating a logger.");
+            throw new TypeError("You must supply a name when creating a logger.");
         }
 
         var logger = _loggersByName[name];
         if (!logger) {
-          logger = _loggersByName[name] = new Logger(
-            name, defaultLogger.getLevel(), defaultLogger.methodFactory);
+            logger = _loggersByName[name] = new Logger(
+                name,
+                defaultLogger.methodFactory
+            );
         }
         return logger;
     };

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -31,6 +31,9 @@
         "error"
     ];
 
+    var _loggersByName = {};
+    var defaultLogger = null;
+
     // Cross-browser bind equivalent that works at least back to IE6
     function bindMethod(obj, methodName) {
         var method = obj[methodName];
@@ -218,10 +221,7 @@
               if (persist !== false) {  // defaults to true
                   persistLevelIfPossible(level);
               }
-              replaceLoggingMethods.call(self, level, name);
-              if (typeof console === undefinedType && level < self.levels.SILENT) {
-                  return "No console available for logging";
-              }
+              return self.rebuild();
           } else {
               throw "log.setLevel() called with invalid level: " + level;
           }
@@ -247,6 +247,27 @@
           self.setLevel(self.levels.SILENT, persist);
       };
 
+      self.rebuild = function (includeChildren) {
+          // NOTE: includeChildren should default to `true` in v2.
+          includeChildren = !!includeChildren;
+
+          replaceLoggingMethods.call(self, currentLevel, name);
+          if (
+              typeof console === undefinedType &&
+              currentLevel < self.levels.SILENT
+          ) {
+              return "No console available for logging";
+          }
+
+          if (includeChildren && defaultLogger === self) {
+              for (var childName in _loggersByName) {
+                var child = _loggersByName[childName];
+                child.setDefaultLevel(currentLevel);
+                child.rebuild(includeChildren);
+              }
+          }
+      };
+
       // Initialize with the right level
       var initialLevel = getPersistedLevel();
       if (initialLevel == null) {
@@ -261,9 +282,8 @@
      *
      */
 
-    var defaultLogger = new Logger();
+    defaultLogger = new Logger();
 
-    var _loggersByName = {};
     defaultLogger.getLogger = function getLogger(name) {
         if ((typeof name !== "symbol" && typeof name !== "string") || name === "") {
           throw new TypeError("You must supply a name when creating a logger.");

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -86,25 +86,33 @@
 
     // These private functions always need `this` to be set properly
 
-    function replaceLoggingMethods(level, loggerName) {
+    function replaceLoggingMethods() {
         /*jshint validthis:true */
+        var level = this.getLevel();
+
+        // Replace the actual methods.
         for (var i = 0; i < logMethods.length; i++) {
             var methodName = logMethods[i];
             this[methodName] = (i < level) ?
                 noop :
-                this.methodFactory(methodName, level, loggerName);
+                this.methodFactory(methodName, level, this.name);
         }
 
         // Define log.log as an alias for log.debug
         this.log = this.debug;
+
+        // Return any important warnings.
+        if (typeof console === undefinedType && level < this.levels.SILENT) {
+            return "No console available for logging";
+        }
     }
 
     // In old IE versions, the console isn't present until you first open it.
     // We build realMethod() replacements here that regenerate logging methods
-    function enableLoggingWhenConsoleArrives(methodName, level, loggerName) {
+    function enableLoggingWhenConsoleArrives(methodName) {
         return function () {
             if (typeof console !== undefinedType) {
-                replaceLoggingMethods.call(this, level, loggerName);
+                replaceLoggingMethods.call(this);
                 this[methodName].apply(this, arguments);
             }
         };
@@ -112,7 +120,7 @@
 
     // By default, we use closely bound real methods wherever possible, and
     // otherwise we wait for a console to appear, and then try again.
-    function defaultMethodFactory(methodName, level, loggerName) {
+    function defaultMethodFactory(methodName, _level, _loggerName) {
         /*jshint validthis:true */
         return realMethod(methodName) ||
                enableLoggingWhenConsoleArrives.apply(this, arguments);
@@ -226,15 +234,6 @@
           }
       }
 
-      function rebuildLoggingMethods() {
-          var level = self.getLevel();
-
-          replaceLoggingMethods.call(self, level, name);
-          if (typeof console === undefinedType && level < self.levels.SILENT) {
-              return "No console available for logging";
-          }
-      }
-
       /*
        *
        * Public logger API - see https://github.com/pimterry/loglevel for details
@@ -265,7 +264,7 @@
           }
 
           // NOTE: in v2, this should call rebuild(), which updates children.
-          return rebuildLoggingMethods();
+          return replaceLoggingMethods.call(this);
       };
 
       self.setDefaultLevel = function (level) {
@@ -278,7 +277,7 @@
       self.resetLevel = function () {
           userLevel = null;
           clearPersistedLevel();
-          rebuildLoggingMethods();
+          replaceLoggingMethods.call(this);
       };
 
       self.enableAll = function(persist) {
@@ -293,7 +292,7 @@
           if (defaultLogger !== self) {
               inheritedLevel = normalizeLevel(defaultLogger.getLevel());
           }
-          rebuildLoggingMethods();
+          replaceLoggingMethods.call(this);
 
           if (defaultLogger === self) {
               for (var childName in _loggersByName) {
@@ -313,7 +312,7 @@
       if (initialLevel != null) {
           userLevel = normalizeLevel(initialLevel);
       }
-      rebuildLoggingMethods();
+      replaceLoggingMethods.call(this);
     }
 
     /*

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -207,6 +207,15 @@
           }
       }
 
+      function rebuildLoggingMethods() {
+          var level = self.getLevel();
+
+          replaceLoggingMethods.call(self, level, name);
+          if (typeof console === undefinedType && level < self.levels.SILENT) {
+              return "No console available for logging";
+          }
+      }
+
       /*
        *
        * Public logger API - see https://github.com/pimterry/loglevel for details
@@ -230,13 +239,15 @@
           if (persist !== false) {  // defaults to true
               persistLevelIfPossible(level);
           }
-          return self.rebuild();
+          // NOTE: in v2, this should call rebuild(), which is recursive.
+          return rebuildLoggingMethods();
       };
 
       self.setDefaultLevel = function (level) {
           defaultLevel = normalizeLevel(level);
           if (currentLevel == null) {
-            self.rebuild();
+              // NOTE: in v2, this should call rebuild(), which is recursive.
+              rebuildLoggingMethods();
           }
       };
 
@@ -254,20 +265,14 @@
           self.setLevel(self.levels.SILENT, persist);
       };
 
-      self.rebuild = function (includeChildren) {
-          // NOTE: includeChildren should default to `true` in v2.
-          includeChildren = !!includeChildren;
-          var level = self.getLevel();
+      self.rebuild = function () {
+          rebuildLoggingMethods();
 
-          replaceLoggingMethods.call(self, level, name);
-          if (typeof console === undefinedType && level < self.levels.SILENT) {
-              return "No console available for logging";
-          }
+          if (defaultLogger === self) {
+              var level = self.getLevel();
 
-          if (includeChildren && defaultLogger === self) {
               for (var childName in _loggersByName) {
-                var child = _loggersByName[childName];
-                child.setDefaultLevel(level);
+                _loggersByName[childName].setDefaultLevel(level);
               }
           }
       };

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -305,9 +305,6 @@
       inheritedLevel = normalizeLevel(
           defaultLogger ? defaultLogger.getLevel() : "WARN"
       );
-      if (defaultLevel != null) {
-          defaultLevel = normalizeLevel(defaultLevel);
-      }
       var initialLevel = getPersistedLevel();
       if (initialLevel != null) {
           userLevel = normalizeLevel(initialLevel);

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -195,6 +195,18 @@
           } catch (ignore) {}
       }
 
+      function normalizeLevel(input) {
+          var level = input;
+          if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
+              level = self.levels[level.toUpperCase()];
+          }
+          if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
+              return level;
+          } else {
+              throw new TypeError("log.setLevel() called with invalid level: " + input);
+          }
+      }
+
       /*
        *
        * Public logger API - see https://github.com/pimterry/loglevel for details
@@ -209,34 +221,29 @@
       self.methodFactory = factory || defaultMethodFactory;
 
       self.getLevel = function () {
-          return currentLevel;
+          return currentLevel == null ? defaultLevel : currentLevel;
       };
 
       self.setLevel = function (level, persist) {
-          if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
-              level = self.levels[level.toUpperCase()];
+          level = normalizeLevel(level);
+          currentLevel = level;
+          if (persist !== false) {  // defaults to true
+              persistLevelIfPossible(level);
           }
-          if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
-              currentLevel = level;
-              if (persist !== false) {  // defaults to true
-                  persistLevelIfPossible(level);
-              }
-              return self.rebuild();
-          } else {
-              throw "log.setLevel() called with invalid level: " + level;
-          }
+          return self.rebuild();
       };
 
       self.setDefaultLevel = function (level) {
-          defaultLevel = level;
-          if (!getPersistedLevel()) {
-              self.setLevel(level, false);
+          defaultLevel = normalizeLevel(level);
+          if (currentLevel == null) {
+            self.rebuild();
           }
       };
 
       self.resetLevel = function () {
-          self.setLevel(defaultLevel, false);
           clearPersistedLevel();
+          currentLevel = null;
+          self.setDefaultLevel(defaultLevel);
       };
 
       self.enableAll = function(persist) {
@@ -250,20 +257,17 @@
       self.rebuild = function (includeChildren) {
           // NOTE: includeChildren should default to `true` in v2.
           includeChildren = !!includeChildren;
+          var level = self.getLevel();
 
-          replaceLoggingMethods.call(self, currentLevel, name);
-          if (
-              typeof console === undefinedType &&
-              currentLevel < self.levels.SILENT
-          ) {
+          replaceLoggingMethods.call(self, level, name);
+          if (typeof console === undefinedType && level < self.levels.SILENT) {
               return "No console available for logging";
           }
 
           if (includeChildren && defaultLogger === self) {
               for (var childName in _loggersByName) {
                 var child = _loggersByName[childName];
-                child.setDefaultLevel(currentLevel);
-                child.rebuild(includeChildren);
+                child.setDefaultLevel(level);
               }
           }
       };
@@ -271,9 +275,10 @@
       // Initialize with the right level
       var initialLevel = getPersistedLevel();
       if (initialLevel == null) {
-          initialLevel = defaultLevel;
+          self.setDefaultLevel(defaultLevel);
+      } else {
+          self.setLevel(initialLevel, false);
       }
-      self.setLevel(initialLevel, false);
     }
 
     /*

--- a/test/level-setting-test.js
+++ b/test/level-setting-test.js
@@ -64,31 +64,31 @@ define(['../lib/loglevel'], function(log) {
             it("no level argument", function() {
                 expect(function() {
                     log.setLevel();
-                }).toThrow("log.setLevel() called with invalid level: undefined");
+                }).toThrowError(TypeError, "log.setLevel() called with invalid level: undefined");
             });
 
             it("a null level argument", function() {
                 expect(function() {
                     log.setLevel(null);
-                }).toThrow("log.setLevel() called with invalid level: null");
+                }).toThrowError(TypeError, "log.setLevel() called with invalid level: null");
             });
 
             it("an undefined level argument", function() {
                 expect(function() {
                     log.setLevel(undefined);
-                }).toThrow("log.setLevel() called with invalid level: undefined");
+                }).toThrowError(TypeError, "log.setLevel() called with invalid level: undefined");
             });
 
             it("an invalid log level index", function() {
                 expect(function() {
                     log.setLevel(-1);
-                }).toThrow("log.setLevel() called with invalid level: -1");
+                }).toThrowError(TypeError, "log.setLevel() called with invalid level: -1");
             });
 
             it("an invalid log level name", function() {
                 expect(function() {
                     log.setLevel("InvalidLevelName");
-                }).toThrow("log.setLevel() called with invalid level: InvalidLevelName");
+                }).toThrowError(TypeError, "log.setLevel() called with invalid level: InvalidLevelName");
             });
         });
 

--- a/test/multiple-logger-test.js
+++ b/test/multiple-logger-test.js
@@ -151,6 +151,70 @@ define(['test/test-helpers'], function(testHelpers) {
             });
         });
 
+        describe("logger.resetLevel()", function() {
+            beforeEach(function() {
+                window.console = {"log" : jasmine.createSpy("console.log")};
+                jasmine.addMatchers({
+                    "toBeAtLevel" : testHelpers.toBeAtLevel
+                });
+                testHelpers.clearStoredLevels();
+            });
+
+            afterEach(function() {
+                window.console = originalConsole;
+            });
+
+            it("resets to the inherited level if no local level was set", function(log) {
+                testHelpers.setStoredLevel("ERROR", "newLogger");
+
+                log.setLevel("TRACE");
+                var newLogger = log.getLogger("newLogger");
+                expect(newLogger).toBeAtLevel("ERROR");
+
+                newLogger.resetLevel();
+                expect(newLogger).toBeAtLevel("TRACE");
+
+                // resetLevel() should not have broken inheritance.
+                log.setLevel("DEBUG");
+                log.rebuild();
+                expect(newLogger).toBeAtLevel("DEBUG");
+            });
+
+            it("resets to the inherited level if no default level was set", function(log) {
+                log.setLevel("TRACE");
+                var newLogger = log.getLogger("newLogger");
+                expect(newLogger).toBeAtLevel("TRACE");
+
+                newLogger.setLevel("ERROR");
+                expect(newLogger).toBeAtLevel("ERROR");
+
+                newLogger.resetLevel();
+                expect(newLogger).toBeAtLevel("TRACE");
+
+                // resetLevel() should not have broken inheritance.
+                log.setLevel("DEBUG");
+                log.rebuild();
+                expect(newLogger).toBeAtLevel("DEBUG");
+            });
+
+            it("resets to the default level if one was set", function(log) {
+                testHelpers.setStoredLevel("ERROR", "newLogger");
+
+                log.setLevel("TRACE");
+                var newLogger = log.getLogger("newLogger");
+                newLogger.setDefaultLevel("INFO");
+                expect(newLogger).toBeAtLevel("ERROR");
+
+                newLogger.resetLevel();
+                expect(newLogger).toBeAtLevel("INFO");
+
+                // resetLevel() should not have caused inheritance to start.
+                log.setLevel("DEBUG");
+                log.rebuild();
+                expect(newLogger).toBeAtLevel("INFO");
+            });
+        });
+
         describe("logger.rebuild()", function() {
             beforeEach(function() {
                 window.console = {"log" : jasmine.createSpy("console.log")};

--- a/test/multiple-logger-test.js
+++ b/test/multiple-logger-test.js
@@ -172,7 +172,7 @@ define(['test/test-helpers'], function(testHelpers) {
                 log.setLevel("ERROR");
                 expect(newLogger).toBeAtLevel("TRACE");
 
-                log.rebuild(true);
+                log.rebuild();
                 expect(newLogger).toBeAtLevel("ERROR");
             });
 
@@ -183,16 +183,27 @@ define(['test/test-helpers'], function(testHelpers) {
                 var newLogger = log.getLogger("newLogger");
                 expect(newLogger).toBeAtLevel("ERROR");
 
-                log.rebuild(true);
+                log.rebuild();
                 expect(newLogger).toBeAtLevel("ERROR");
             });
 
-            it("should not change a child's explicitly set level even if un-persisted", function(log) {
+            it("should not change a child's level set with `setLevel()`", function(log) {
                 log.setLevel("TRACE");
                 var newLogger = log.getLogger("newLogger");
-                newLogger.setLevel("DEBUG", false);
+                expect(newLogger).toBeAtLevel("TRACE");
 
-                log.rebuild(true);
+                newLogger.setLevel("DEBUG", false);
+                log.rebuild();
+                expect(newLogger).toBeAtLevel("DEBUG");
+            });
+
+            it("should not change a child's level set with `setDefaultLevel()`", function(log) {
+                log.setLevel("TRACE");
+                var newLogger = log.getLogger("newLogger");
+                expect(newLogger).toBeAtLevel("TRACE");
+
+                newLogger.setDefaultLevel("DEBUG");
+                log.rebuild();
                 expect(newLogger).toBeAtLevel("DEBUG");
             });
         });

--- a/test/multiple-logger-test.js
+++ b/test/multiple-logger-test.js
@@ -149,6 +149,29 @@ define(['test/test-helpers'], function(testHelpers) {
               var newLogger = log.getLogger("newLogger");
               expect(newLogger).toBeAtLevel("trace");
             });
+
+            it("rebuilds existing child loggers via root.rebuild(children=true)", function(log) {
+                log.setLevel("TRACE");
+                var newLogger = log.getLogger("newLogger");
+                expect(newLogger).toBeAtLevel("TRACE");
+
+                log.setLevel("ERROR");
+                expect(newLogger).toBeAtLevel("TRACE");
+
+                log.rebuild(true);
+                expect(newLogger).toBeAtLevel("ERROR");
+            });
+
+            it("should not change a child's persisted level when calling root.rebuild(children=true)", function(log) {
+                testHelpers.setStoredLevel("ERROR", "newLogger");
+
+                log.setLevel("TRACE");
+                var newLogger = log.getLogger("newLogger");
+                expect(newLogger).toBeAtLevel("ERROR");
+
+                log.rebuild(true);
+                expect(newLogger).toBeAtLevel("ERROR");
+            });
         });
     });
 });

--- a/test/multiple-logger-test.js
+++ b/test/multiple-logger-test.js
@@ -149,8 +149,22 @@ define(['test/test-helpers'], function(testHelpers) {
               var newLogger = log.getLogger("newLogger");
               expect(newLogger).toBeAtLevel("trace");
             });
+        });
 
-            it("rebuilds existing child loggers via root.rebuild(children=true)", function(log) {
+        describe("logger.rebuild()", function() {
+            beforeEach(function() {
+                window.console = {"log" : jasmine.createSpy("console.log")};
+                jasmine.addMatchers({
+                    "toBeAtLevel" : testHelpers.toBeAtLevel
+                });
+                testHelpers.clearStoredLevels();
+            });
+
+            afterEach(function() {
+                window.console = originalConsole;
+            });
+
+            it("rebuilds existing child loggers", function(log) {
                 log.setLevel("TRACE");
                 var newLogger = log.getLogger("newLogger");
                 expect(newLogger).toBeAtLevel("TRACE");
@@ -162,7 +176,7 @@ define(['test/test-helpers'], function(testHelpers) {
                 expect(newLogger).toBeAtLevel("ERROR");
             });
 
-            it("should not change a child's persisted level when calling root.rebuild(children=true)", function(log) {
+            it("should not change a child's persisted level", function(log) {
                 testHelpers.setStoredLevel("ERROR", "newLogger");
 
                 log.setLevel("TRACE");
@@ -173,7 +187,7 @@ define(['test/test-helpers'], function(testHelpers) {
                 expect(newLogger).toBeAtLevel("ERROR");
             });
 
-            it("should not change a child's explicitly set level even if un-persisted when calling root.rebuild(children=true)", function(log) {
+            it("should not change a child's explicitly set level even if un-persisted", function(log) {
                 log.setLevel("TRACE");
                 var newLogger = log.getLogger("newLogger");
                 newLogger.setLevel("DEBUG", false);

--- a/test/multiple-logger-test.js
+++ b/test/multiple-logger-test.js
@@ -172,6 +172,15 @@ define(['test/test-helpers'], function(testHelpers) {
                 log.rebuild(true);
                 expect(newLogger).toBeAtLevel("ERROR");
             });
+
+            it("should not change a child's explicitly set level even if un-persisted when calling root.rebuild(children=true)", function(log) {
+                log.setLevel("TRACE");
+                var newLogger = log.getLogger("newLogger");
+                newLogger.setLevel("DEBUG", false);
+
+                log.rebuild(true);
+                expect(newLogger).toBeAtLevel("DEBUG");
+            });
         });
     });
 });


### PR DESCRIPTION
This resolves #187 by adding a new `Logger.rebuild(includeChildren)` method, which takes care of using the `methodFactory` to update all the logging methods according to the current level. If the `includeChildren` argument is set to `true` and the method is called on the root logger, it will recursively rebuild all the child loggers (it is `false` by default, but in some future v2, it should probably be changed to `true`).

The `includeChildren` argument is mainly useful for two cases:

1. When applying a plugin or modifying the logger’s `methodFactory`, it can be used to update previously existing child loggers, so you can divorce logger configuration code from logger declaration code. Ideally, plugin developers will call this from their plugin’s apply/register/whatever code. But a user could call it directly if a plugin developer does not.

2. When changing the level on the root logger and you want that new level to apply to already existing child loggers (that you haven’t called `setLevel()` on and that didn’t have persisted levels). This essentially lets you treat a logger’s “default” level as if it means “whatever my parent/root logger’s current level is.”

So in #187, the example problem code could be updated slightly to make everything work right:

```js
// In `a-random-submodule.js`
import log from 'loglevel'

const logger = log.getLogger('DefaultUiAutomationWorker');
```

```js
// In `index.js`
import aRandomSubmodule from 'a-random-submodule.js';
import log from 'loglevel';
import logPrefix from 'loglevel-plugin-prefix';

function main() {
    logPrefix.reg(log);
    logPrefix.apply(log, { template: '[%t] %l %n:' });
    log.enableAll();
    log.rebuild(true);  // Adding this line is the only change.

    // start rest of program here
}

main();
```

### Other Notes

- In the discussion on #187, we talked about calling this `rebuildLogger()`. I named it `rebuild()` here because I thought that was just as clear and a bit more concise, but I’m happy to change it if you’d prefer.

- I made a small note in the code that `includeChildren` should default to `true` in some future v2 of the library. As discussed in #187, having `setLevel()` affect pre-existing child loggers is probably the right ideal, but might cause subtle breakage, so for now I just made `rebuild()` only affect the current level by default. Flipping the default in the future will also affect the behavior of `setLevel()` and `setDefaultLevel()` since they use `rebuild()` internally. 

    Another option here is to make the default `true` but having `setLevel()` and `setDefaultLevel()` call it with `false` (so `log.rebuild()` affects child loggers by default, but `setLevel()` and `setDefaultLevel()` do not). I think either way would probably be fine. 🤷 

- There are a few subtle side-effects here:

    - The `currentLevel` private variable used to always be a valid level. It no longer is — you should always call `logger.getLevel()` to get the current level. (`defaultLevel` will always be set and valid; `currentLevel` will only be set if `setLevel()` was explicitly called or a persisted level was loaded.) This shouldn’t affect the public interface at all, and I’ve made sure all internal callsites do the right thing.

    - `setLevel()` throws a `TypeError` instead of a `string` for invalid input. I don’t think this should really be an issue, and it arguably improves errors slightly (IMO throwing or rejecting with things that aren’t instances `Error` or a sub-type is problematic). But I can change it back if you prefer.