### PR TITLE
Run TypeScript tests in ts-node

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -264,7 +264,7 @@
           }
 
           // NOTE: in v2, this should call rebuild(), which updates children.
-          return replaceLoggingMethods.call(this);
+          return replaceLoggingMethods.call(self);
       };
 
       self.setDefaultLevel = function (level) {

--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -264,7 +264,7 @@
           }
 
           // NOTE: in v2, this should call rebuild(), which updates children.
-          return replaceLoggingMethods.call(self);
+          return replaceLoggingMethods.call(this);
       };
 
       self.setDefaultLevel = function (level) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "grunt test && npm run test-types",
     "test-browser": "grunt test-browser",
     "test-node": "grunt test-node",
-    "test-types": "tsc --noEmit ./test/type-test.ts",
+    "test-types": "tsc --noEmit ./test/type-test.ts && ts-node ./test/type-test.ts",
     "dist": "grunt dist",
     "dist-build": "grunt dist-build",
     "watch": "grunt watch"
@@ -51,6 +51,7 @@
     "grunt-open": "~0.2.3",
     "grunt-preprocess": "^5.1.0",
     "jasmine": "^2.4.1",
+    "ts-node": "^10.9.2",
     "typescript": "^3.5.1"
   },
   "keywords": [


### PR DESCRIPTION
We previously ran the `test/type-test.ts` test through the TypeScript compiler to catch type issues, but there are more subtle problems that can happen at runtime with tools like `ts-node` (and maybe things like Deno, too — I haven't tested that). This actually *runs* the test file in ts-node to make sure it doesn't throw at runtime, which would have caught issues like #196 ahead of time.

~⚠️ This isn’t ready to merge. I added a commit that *should* cause the test to fail (partly reverting the fix for #196). If it fails, that I’ll take that back out and it should be merge-able.~